### PR TITLE
Add SF Symbol icons to menu items

### DIFF
--- a/CopilotMonitor/CopilotMonitor/App/StatusBarController.swift
+++ b/CopilotMonitor/CopilotMonitor/App/StatusBarController.swift
@@ -503,6 +503,7 @@ final class StatusBarController: NSObject {
         loadCachedHistoryOnStartup()
         
         signInItem = NSMenuItem(title: "Sign In", action: #selector(signInClicked), keyEquivalent: "")
+        signInItem.image = NSImage(systemSymbolName: "person.crop.circle.badge.checkmark", accessibilityDescription: "Sign In")
         signInItem.target = self
         menu.addItem(signInItem)
 
@@ -512,14 +513,17 @@ final class StatusBarController: NSObject {
         menu.addItem(resetLoginItem)
         
         let refreshItem = NSMenuItem(title: "Refresh", action: #selector(refreshClicked), keyEquivalent: "r")
+        refreshItem.image = NSImage(systemSymbolName: "arrow.clockwise", accessibilityDescription: "Refresh")
         refreshItem.target = self
         menu.addItem(refreshItem)
         
         let checkForUpdatesItem = NSMenuItem(title: "Check for Updates...", action: #selector(checkForUpdatesClicked), keyEquivalent: "u")
+        checkForUpdatesItem.image = NSImage(systemSymbolName: "arrow.down.circle", accessibilityDescription: "Check for Updates")
         checkForUpdatesItem.target = self
         menu.addItem(checkForUpdatesItem)
         
         let refreshIntervalItem = NSMenuItem(title: "Auto Refresh", action: nil, keyEquivalent: "")
+        refreshIntervalItem.image = NSImage(systemSymbolName: "timer", accessibilityDescription: "Auto Refresh")
         refreshIntervalMenu = NSMenu()
         for interval in RefreshInterval.allCases {
             let item = NSMenuItem(title: interval.title, action: #selector(refreshIntervalSelected(_:)), keyEquivalent: "")
@@ -541,17 +545,20 @@ final class StatusBarController: NSObject {
         updatePredictionPeriodMenu()
         
         let openBillingItem = NSMenuItem(title: "Open Billing", action: #selector(openBillingClicked), keyEquivalent: "b")
+        openBillingItem.image = NSImage(systemSymbolName: "creditcard", accessibilityDescription: "Open Billing")
         openBillingItem.target = self
         menu.addItem(openBillingItem)
         
         menu.addItem(NSMenuItem.separator())
         launchAtLoginItem = NSMenuItem(title: "Launch at Login", action: #selector(launchAtLoginClicked), keyEquivalent: "")
+        launchAtLoginItem.image = NSImage(systemSymbolName: "power", accessibilityDescription: "Launch at Login")
         launchAtLoginItem.target = self
         updateLaunchAtLoginState()
         menu.addItem(launchAtLoginItem)
         
         menu.addItem(NSMenuItem.separator())
         let quitItem = NSMenuItem(title: "Quit", action: #selector(quitClicked), keyEquivalent: "q")
+        quitItem.image = NSImage(systemSymbolName: "xmark.circle", accessibilityDescription: "Quit")
         quitItem.target = self
         menu.addItem(quitItem)
         statusItem.menu = menu


### PR DESCRIPTION
### Motivation
- Add SF Symbol icons to previously icon-less menu items to improve visual clarity and follow the UI styling rules.

### Description
- Added `NSImage(systemSymbolName:accessibilityDescription:)` icons to multiple menu items in `CopilotMonitor/CopilotMonitor/App/StatusBarController.swift`, including `Sign In`, `Refresh`, `Check for Updates...`, `Auto Refresh`, `Open Billing`, `Launch at Login`, and `Quit`.

### Testing
- Attempted to build with `pkill -x CopilotMonitor; xcodebuild -project CopilotMonitor/CopilotMonitor.xcodeproj -scheme CopilotMonitor -configuration Debug build && open ~/Library/Developer/Xcode/DerivedData/CopilotMonitor-*/Build/Products/Debug/CopilotMonitor.app`, but the command failed because `xcodebuild` is not available in the environment, so no automated build/tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ee90ba09483218c0a05b65e449a65)