### PR TITLE
fix: Remove the blank Settings window when the app launch

### DIFF
--- a/CopilotMonitor/CopilotMonitor/App/AppDelegate.swift
+++ b/CopilotMonitor/CopilotMonitor/App/AppDelegate.swift
@@ -14,8 +14,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private(set) var updaterController: SPUStandardUpdaterController!
     
     func applicationDidFinishLaunching(_ notification: Notification) {
-        // Sparkle 초기화 - 앱 시작 시 자동 업데이트 체크 시작
-        // startingUpdater: true로 설정하여 앱 시작과 동시에 업데이트 체크
         updaterController = SPUStandardUpdaterController(
             startingUpdater: true,
             updaterDelegate: nil,
@@ -24,6 +22,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         statusBarController = StatusBarController()
         setupNotificationObservers()
+        
+        closeAllWindows()
+    }
+    
+    private func closeAllWindows() {
+        for window in NSApp.windows where window.title.contains("Settings") {
+            window.close()
+        }
     }
     
     private func setupNotificationObservers() {

--- a/CopilotMonitor/CopilotMonitor/CopilotMonitorApp.swift
+++ b/CopilotMonitor/CopilotMonitor/CopilotMonitorApp.swift
@@ -8,5 +8,6 @@ struct CopilotMonitorApp: App {
         Settings {
             EmptyView()
         }
+        .windowResizability(.contentSize)
     }
 }


### PR DESCRIPTION
## Summary
- 앱 실행 시 불필요한 빈 'CopilotMonitor Settings' 창이 자동으로 열리는 문제 수정
- SwiftUI Settings Scene이 상태 복원으로 인해 표시되는 것을 방지

## Changes
- `AppDelegate.applicationDidFinishLaunching`에서 Settings 창 자동 닫기 로직 추가
- `closeAllWindows()` 메서드로 "Settings" 제목 포함 창 닫기

## Testing
- 앱 실행 시 빈 Settings 창이 더 이상 나타나지 않음 확인