### PR TITLE
fix: include billed requests in usage prediction calculation

### DIFF
--- a/CopilotMonitor/CopilotMonitor/App/StatusBarController.swift
+++ b/CopilotMonitor/CopilotMonitor/App/StatusBarController.swift
@@ -1086,7 +1086,7 @@ final class StatusBarController: NSObject {
                 self.lastHistoryFetchResult = .success
                 self.saveHistoryCache(history)
                 
-                logger.info("fetchUsageHistoryNow: 완료, days.count=\(history.days.count), totalRequests=\(history.totalIncludedRequests)")
+                logger.info("fetchUsageHistoryNow: 완료, days.count=\(history.days.count), totalRequests=\(history.totalRequests)")
                 self.updateHistorySubmenu()
             } catch {
                 logger.error("fetchUsageHistoryNow: 실패 - \(error.localizedDescription)")
@@ -1238,7 +1238,7 @@ final class StatusBarController: NSObject {
                 let dayStart = utcCalendar.startOfDay(for: day.date)
                 let isToday = dayStart == today
                 let dateStr = dateFormatter.string(from: day.date)
-                let reqStr = numberFormatter.string(from: NSNumber(value: day.includedRequests)) ?? "0"
+                let reqStr = numberFormatter.string(from: NSNumber(value: day.totalRequests)) ?? "0"
                 let label = isToday ? "\(dateStr) (Today): \(reqStr) req" : "\(dateStr): \(reqStr) req"
                 
                 let item = NSMenuItem(title: label, action: nil, keyEquivalent: "")

--- a/CopilotMonitor/CopilotMonitor/Models/UsageHistory.swift
+++ b/CopilotMonitor/CopilotMonitor/Models/UsageHistory.swift
@@ -16,13 +16,16 @@ struct DailyUsage: Codable {
     
     var dayOfWeek: Int { Self.utcCalendar.component(.weekday, from: date) }
     var isWeekend: Bool { dayOfWeek == 1 || dayOfWeek == 7 }
+    
+    /// Total requests (included + billed) for prediction calculations
+    var totalRequests: Double { includedRequests + billedRequests }
 }
 
 struct UsageHistory: Codable {
     let fetchedAt: Date
     let days: [DailyUsage]       // ⚠️ Stores full month data (separate from 7-day UI display)
     
-    var totalIncludedRequests: Double { days.reduce(0) { $0 + $1.includedRequests } }
+    var totalRequests: Double { days.reduce(0) { $0 + $1.totalRequests } }
     var totalBilledAmount: Double { days.reduce(0) { $0 + $1.billedAmount } }
     
     // Recent 7 days slice for UI

--- a/CopilotMonitor/CopilotMonitor/Services/UsagePredictor.swift
+++ b/CopilotMonitor/CopilotMonitor/Services/UsagePredictor.swift
@@ -82,7 +82,7 @@ class UsagePredictor {
         let predictedRemainingWeekdayUsage = weightedAvgDailyUsage * Double(remainingWeekdays)
         let predictedRemainingWeekendUsage = weightedAvgDailyUsage * weekendRatio * Double(remainingWeekends)
         
-        let currentTotalUsage = history.totalIncludedRequests
+        let currentTotalUsage = history.totalRequests
         let predictedMonthlyTotal = currentTotalUsage + predictedRemainingWeekdayUsage + predictedRemainingWeekendUsage
         
         // Step 5: Calculate predicted add-on cost
@@ -132,7 +132,7 @@ class UsagePredictor {
         let daysToUse = min(sortedData.count, weights.count)
         
         for i in 0..<daysToUse {
-            let usage = sortedData[i].includedRequests  // Already Double
+            let usage = sortedData[i].totalRequests  // Use totalRequests (included + billed)
             let weight = weights[i]
             weightedSum += usage * weight
             totalWeight += weight
@@ -163,11 +163,11 @@ class UsagePredictor {
             // weekday: 1=Sunday, 2=Monday, ..., 7=Saturday
             if weekday == 1 || weekday == 7 {
                 // Weekend (Sun, Sat)
-                weekendSum += day.includedRequests
+                weekendSum += day.totalRequests
                 weekendCount += 1
             } else {
                 // Weekday (Mon-Fri)
-                weekdaySum += day.includedRequests
+                weekdaySum += day.totalRequests
                 weekdayCount += 1
             }
         }


### PR DESCRIPTION
## Summary
- 기존에 **Included requests**만 예측 계산에 포함되고 **Billed requests**는 무시되던 버그 수정

## Changes
- `DailyUsage`에 `totalRequests` computed property 추가 (`includedRequests + billedRequests`)
- `UsagePredictor`에서 가중 평균, 주말/주중 비율 계산 시 `totalRequests` 사용
- UI 일일 사용량 표시에도 `totalRequests` 반영

## Files Modified
| File | Change |
|------|--------|
| `UsageHistory.swift` | `totalRequests` property 추가, `totalIncludedRequests` → `totalRequests` |
| `UsagePredictor.swift` | 예측 계산 로직에서 `totalRequests` 사용 |
| `StatusBarController.swift` | 로그 및 UI 표시 수정 |