### PR TITLE
fix: cost display bug and add version to menu

### DIFF
--- a/CopilotMonitor/CopilotMonitor/App/StatusBarController.swift
+++ b/CopilotMonitor/CopilotMonitor/App/StatusBarController.swift
@@ -557,6 +557,13 @@ final class StatusBarController: NSObject {
         menu.addItem(launchAtLoginItem)
         
         menu.addItem(NSMenuItem.separator())
+        
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+        let versionItem = NSMenuItem(title: "Version \(version)", action: nil, keyEquivalent: "")
+        versionItem.image = NSImage(systemSymbolName: "info.circle", accessibilityDescription: "Version")
+        versionItem.isEnabled = false
+        menu.addItem(versionItem)
+        
         let quitItem = NSMenuItem(title: "Quit", action: #selector(quitClicked), keyEquivalent: "q")
         quitItem.image = NSImage(systemSymbolName: "xmark.circle", accessibilityDescription: "Quit")
         quitItem.target = self
@@ -848,6 +855,9 @@ final class StatusBarController: NSObject {
             }
             if let value = dict[key] as? Int {
                 return Double(value)
+            }
+            if let value = dict[key] as? NSNumber {
+                return value.doubleValue
             }
         }
         return 0.0

--- a/CopilotMonitor/CopilotMonitor/Services/UsageFetcher.swift
+++ b/CopilotMonitor/CopilotMonitor/Services/UsageFetcher.swift
@@ -98,11 +98,11 @@ final class UsageFetcher {
             throw UsageFetcherError.parsingFailed(errorMsg)
         }
         
-        let netBilledAmount = (dict["netBilledAmount"] as? Double) ?? (dict["netBilledAmount"] as? Int).map { Double($0) } ?? 0.0
-        let netQuantity = (dict["netQuantity"] as? Double) ?? (dict["netQuantity"] as? Int).map { Double($0) } ?? 0.0
-        let discountQuantity = (dict["discountQuantity"] as? Double) ?? (dict["discountQuantity"] as? Int).map { Double($0) } ?? 0.0
-        let userPremiumRequestEntitlement = (dict["userPremiumRequestEntitlement"] as? Int) ?? (dict["userPremiumRequestEntitlement"] as? Double).map { Int($0) } ?? 0
-        let filteredUserPremiumRequestEntitlement = (dict["filteredUserPremiumRequestEntitlement"] as? Int) ?? (dict["filteredUserPremiumRequestEntitlement"] as? Double).map { Int($0) } ?? 0
+        let netBilledAmount = (dict["netBilledAmount"] as? Double) ?? (dict["netBilledAmount"] as? Int).map { Double($0) } ?? (dict["netBilledAmount"] as? NSNumber)?.doubleValue ?? 0.0
+        let netQuantity = (dict["netQuantity"] as? Double) ?? (dict["netQuantity"] as? Int).map { Double($0) } ?? (dict["netQuantity"] as? NSNumber)?.doubleValue ?? 0.0
+        let discountQuantity = (dict["discountQuantity"] as? Double) ?? (dict["discountQuantity"] as? Int).map { Double($0) } ?? (dict["discountQuantity"] as? NSNumber)?.doubleValue ?? 0.0
+        let userPremiumRequestEntitlement = (dict["userPremiumRequestEntitlement"] as? Int) ?? (dict["userPremiumRequestEntitlement"] as? Double).map { Int($0) } ?? (dict["userPremiumRequestEntitlement"] as? NSNumber)?.intValue ?? 0
+        let filteredUserPremiumRequestEntitlement = (dict["filteredUserPremiumRequestEntitlement"] as? Int) ?? (dict["filteredUserPremiumRequestEntitlement"] as? Double).map { Int($0) } ?? (dict["filteredUserPremiumRequestEntitlement"] as? NSNumber)?.intValue ?? 0
         
         print("Parsed values: discountQuantity=\(discountQuantity), userPremiumRequestEntitlement=\(userPremiumRequestEntitlement)")
         


### PR DESCRIPTION
## Summary
- Fix cost display showing incorrect value ($64.2 instead of actual $127+) by adding NSNumber type handling for API response parsing
- Add app version display in menu bar dropdown (before Quit item)

## Changes
- `StatusBarController.swift`: Add NSNumber fallback in `parseDoubleValue()`, add version menu item
- `UsageFetcher.swift`: Add NSNumber fallback for all numeric API fields

## Root Cause
JavaScript values passed from WebView to Swift were coming as `NSNumber` instead of `Double`/`Int`, causing the type casting to fail and default to 0.0.