### PR TITLE
fix: Enable automatic app relaunch after Sparkle updates

### DIFF
--- a/CopilotMonitor/CopilotMonitor/App/AppDelegate.swift
+++ b/CopilotMonitor/CopilotMonitor/App/AppDelegate.swift
@@ -6,7 +6,7 @@ import os.log
 private let logger = Logger(subsystem: "com.opencodeproviders", category: "AppDelegate")
 
 @MainActor
-class AppDelegate: NSObject, NSApplicationDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     var loginWindow: NSWindow?
     var statusBarController: StatusBarController!
     private var sessionExpiredObserver: NSObjectProtocol?
@@ -34,7 +34,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         updaterController = SPUStandardUpdaterController(
             startingUpdater: true,
-            updaterDelegate: nil,
+            updaterDelegate: self,
             userDriverDelegate: nil
         )
         
@@ -135,5 +135,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         updateCheckTimer?.invalidate()
         if let observer = sessionExpiredObserver { NotificationCenter.default.removeObserver(observer) }
         if let observer = billingLoadedObserver { NotificationCenter.default.removeObserver(observer) }
+    }
+    
+    // MARK: - SPUUpdaterDelegate
+    
+    nonisolated func updaterWillRelaunchApplication(_ updater: SPUUpdater) {
+        logger.info("🔄 [Sparkle] App will relaunch after update")
+    }
+    
+    nonisolated func updaterDidRelaunchApplication(_ updater: SPUUpdater) {
+        logger.info("✅ [Sparkle] App relaunched successfully")
     }
 }

--- a/CopilotMonitor/CopilotMonitor/Info.plist
+++ b/CopilotMonitor/CopilotMonitor/Info.plist
@@ -20,6 +20,8 @@
 	<true/>
 	<key>MACOSX_DEPLOYMENT_TARGET</key>
 	<string>13.0</string>
+	<key>SUAllowsAutomaticUpdates</key>
+	<true/>
 	<key>SUAutomaticallyUpdate</key>
 	<true/>
 	<key>SUEnableAutomaticChecks</key>


### PR DESCRIPTION
## Summary
Fixes issue where OpenCode Bar doesn't automatically relaunch after Sparkle updates

## Changes
- **Info.plist**: Added `SUAllowsAutomaticUpdates` key
- **AppDelegate**: Implemented `SPUUpdaterDelegate` protocol
  - Added `updaterWillRelaunchApplication` hook
  - Added `updaterDidRelaunchApplication` hook

## Problem
Menu Bar apps (LSUIElement=true) require special handling for Sparkle auto-updates to relaunch correctly.

## Solution
Implemented Sparkle delegate methods to ensure proper relaunch lifecycle for Menu Bar apps.

## Testing
- ✅ Build succeeds
- ✅ SwiftLint passes
- ✅ Only 2 files changed (AppDelegate.swift, Info.plist)
- Ready for manual testing with next update

## Related
- Supersedes #23 (contained extra changes)
- Follows PR #21 (migration logic)