### PR TITLE
feat: add comprehensive environment debug logging on app startup

### DIFF
--- a/CopilotMonitor/CopilotMonitor/App/StatusBarController.swift
+++ b/CopilotMonitor/CopilotMonitor/App/StatusBarController.swift
@@ -85,6 +85,10 @@ final class StatusBarController: NSObject {
     override init() {
         super.init()
         debugLog("StatusBarController init started")
+
+        TokenManager.shared.logDebugEnvironmentInfo()
+        debugLog("Environment debug info logged")
+
         setupStatusItem()
         debugLog("setupStatusItem completed")
         setupMenu()


### PR DESCRIPTION
## Summary
- Add `TokenManager.logDebugEnvironmentInfo()` for comprehensive startup diagnostics
- Automatically logs on app startup to `/tmp/provider_debug.log`

## Debug Info Logged
| Item | Details |
|------|---------|
| auth.json | Existence, line count, byte size |
| ~/.local/share/opencode | Directory contents with file/folder types |
| ~/.config/opencode | Directory contents with file/folder types |
| OpenCode CLI | Existence at ~/.opencode/bin/opencode |
| Tokens | All provider tokens with char counts (masked for security) |
| Antigravity | Account count, active index, emails, project IDs |

## How to Check
```bash
cat /tmp/provider_debug.log | grep -A 50 "Environment Debug Info"
```