### PR TITLE
Add Gemini CLI OAuth fallback for OpenCode auth

### DIFF
--- a/CopilotMonitor/CopilotMonitor/Providers/GeminiCLIProvider.swift
+++ b/CopilotMonitor/CopilotMonitor/Providers/GeminiCLIProvider.swift
@@ -16,10 +16,14 @@ struct GeminiQuotaResponse: Codable {
     let buckets: [Bucket]
 }
 
+struct GeminiUserInfoResponse: Codable {
+    let email: String?
+}
+
 // MARK: - GeminiCLIProvider Implementation
 
 /// Provider for Google Gemini CLI quota tracking via cloudcode-pa.googleapis.com
-/// Uses OAuth token refresh from antigravity-accounts.json
+/// Uses OAuth token refresh from antigravity-accounts.json with fallback to OpenCode auth.json
 final class GeminiCLIProvider: ProviderProtocol {
     let identifier: ProviderIdentifier = .geminiCLI
     let type: ProviderType = .quotaBased
@@ -42,21 +46,23 @@ final class GeminiCLIProvider: ProviderProtocol {
             throw ProviderError.authenticationFailed("No Gemini accounts configured")
         }
 
+        if allAccounts.contains(where: { $0.source == .opencodeAuth }) {
+            logger.info("Gemini CLI: Using OpenCode auth.json fallback for Gemini OAuth")
+        }
+
         var geminiAccountQuotas: [GeminiAccountQuota] = []
         var overallMinPercentage = 100.0
 
         for account in allAccounts {
             do {
                 let quotaResult = try await fetchQuotaForAccount(
-                    refreshToken: account.refreshToken,
-                    accountIndex: account.index,
-                    email: account.email,
-                    projectId: account.projectId
+                    account: account
                 )
                 geminiAccountQuotas.append(quotaResult)
                 overallMinPercentage = min(overallMinPercentage, quotaResult.remainingPercentage)
             } catch {
-                logger.warning("Failed to fetch quota for account #\(account.index + 1) (\(account.email)): \(error.localizedDescription)")
+                let displayEmail = account.email?.isEmpty == false ? account.email ?? "" : "unknown"
+                logger.warning("Failed to fetch quota for account #\(account.index + 1) (\(displayEmail)): \(error.localizedDescription)")
             }
         }
 
@@ -73,8 +79,18 @@ final class GeminiCLIProvider: ProviderProtocol {
             overagePermitted: false
         )
 
+        let authSources = Set(geminiAccountQuotas.map { $0.authSource })
+        let authSourceSummary: String?
+        if authSources.count == 1 {
+            authSourceSummary = authSources.first
+        } else if authSources.count > 1 {
+            authSourceSummary = "Multiple auth sources"
+        } else {
+            authSourceSummary = nil
+        }
+
         let details = DetailedUsage(
-            authSource: "~/.config/opencode/antigravity-accounts.json",
+            authSource: authSourceSummary,
             geminiAccounts: geminiAccountQuotas
         )
 
@@ -83,9 +99,24 @@ final class GeminiCLIProvider: ProviderProtocol {
 
     // MARK: - Private Helpers
 
-    private func fetchQuotaForAccount(refreshToken: String, accountIndex: Int, email: String, projectId: String) async throws -> GeminiAccountQuota {
-        guard let accessToken = await tokenManager.refreshGeminiAccessToken(refreshToken: refreshToken) else {
+    private func fetchQuotaForAccount(account: GeminiAuthAccount) async throws -> GeminiAccountQuota {
+        let accountIndex = account.index
+        let projectId = account.projectId.trimmingCharacters(in: .whitespacesAndNewlines)
+        if projectId.isEmpty {
+            throw ProviderError.authenticationFailed("Missing project ID for account #\(accountIndex + 1)")
+        }
+
+        guard let accessToken = await tokenManager.refreshGeminiAccessToken(
+            refreshToken: account.refreshToken,
+            clientId: account.clientId,
+            clientSecret: account.clientSecret
+        ) else {
             throw ProviderError.authenticationFailed("Unable to refresh token for account #\(accountIndex + 1)")
+        }
+
+        let resolvedEmail = await resolveGeminiAccountEmail(primaryEmail: account.email, accessToken: accessToken)
+        if resolvedEmail == "Unknown" {
+            logger.warning("Gemini CLI: Email lookup failed for account #\(accountIndex + 1)")
         }
 
         guard let url = URL(string: "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota") else {
@@ -147,16 +178,58 @@ final class GeminiCLIProvider: ProviderProtocol {
 
         let remainingPercentage = minFraction * 100.0
 
-        logger.info("Gemini CLI account #\(accountIndex + 1) (\(email)): \(remainingPercentage)% remaining, resets: \(earliestReset?.description ?? "unknown")")
+        logger.info("Gemini CLI account #\(accountIndex + 1) (\(resolvedEmail)): \(remainingPercentage)% remaining, resets: \(earliestReset?.description ?? "unknown")")
 
         return GeminiAccountQuota(
             accountIndex: accountIndex,
-            email: email,
+            email: resolvedEmail,
             remainingPercentage: remainingPercentage,
             modelBreakdown: modelBreakdown,
-            authSource: "~/.config/opencode/antigravity-accounts.json",
+            authSource: account.authSource,
             earliestReset: earliestReset,
             modelResetTimes: modelResetTimes
         )
+    }
+
+    private func resolveGeminiAccountEmail(primaryEmail: String?, accessToken: String) async -> String {
+        if let email = primaryEmail?.trimmingCharacters(in: .whitespacesAndNewlines), !email.isEmpty {
+            return email
+        }
+
+        if let fetchedEmail = await fetchGeminiUserEmail(accessToken: accessToken) {
+            return fetchedEmail
+        }
+
+        return "Unknown"
+    }
+
+    private func fetchGeminiUserEmail(accessToken: String) async -> String? {
+        guard let url = URL(string: "https://www.googleapis.com/oauth2/v1/userinfo?alt=json") else {
+            logger.warning("Gemini CLI: Invalid userinfo endpoint URL")
+            return nil
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                logger.warning("Gemini CLI: Invalid response type from userinfo endpoint")
+                return nil
+            }
+
+            guard httpResponse.statusCode == 200 else {
+                logger.warning("Gemini CLI: Userinfo request failed with status \(httpResponse.statusCode)")
+                return nil
+            }
+
+            let payload = try JSONDecoder().decode(GeminiUserInfoResponse.self, from: data)
+            return payload.email?.trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch {
+            logger.warning("Gemini CLI: Failed to fetch user email: \(error.localizedDescription)")
+            return nil
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@
 
 ### Custom Providers
 
-- **Antigravity**: `NoeFabris/opencode-antigravity-auth`
+- **Antigravity/Gemini**
+  - `NoeFabris/opencode-antigravity-auth`
+  - `jenslys/opencode-gemini-auth`
 - **Claude**: `anomalyco/opencode-anthropic-auth`
 
 ## Features


### PR DESCRIPTION
## Summary
- Add OpenCode auth.json (google OAuth) fallback for Gemini CLI
- Respect OAuth client credentials per auth source
- Enrich Gemini account email via userinfo when missing

## Testing
- xcodebuild -project CopilotMonitor/CopilotMonitor.xcodeproj -scheme CopilotMonitor -configuration Debug clean build