### PR TITLE
Fix orphaned subscription cleanup

### DIFF
--- a/CopilotMonitor/CopilotMonitor/Services/UsagePredictor.swift
+++ b/CopilotMonitor/CopilotMonitor/Services/UsagePredictor.swift
@@ -48,9 +48,9 @@ class UsagePredictor {
         self.weights = weights
     }
 
-    /// 월말 사용량 및 비용 예측
+    /// Predict end-of-month usage and cost
     /// - Parameters:
-    ///   - history: 일별 사용량 히스토리
+    ///   - history: Daily usage history
     ///   - currentUsage: Current usage info (includes limit)
     /// - Returns: Prediction result
     func predict(history: UsageHistory, currentUsage: CopilotUsage) -> UsagePrediction {
@@ -101,7 +101,7 @@ class UsagePredictor {
             predictedBilledAmount = 0
         }
 
-        // Step 6: Confidence Level 결정
+        // Step 6: Determine confidence level
         let daysUsed = dailyData.count
         let confidenceLevel: ConfidenceLevel
 

--- a/CopilotMonitor/CopilotMonitorTests/CLIFormatterTests.swift
+++ b/CopilotMonitor/CopilotMonitorTests/CLIFormatterTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import CopilotMonitor
+@testable import OpenCode_Bar
 
 final class CLIFormatterTests: XCTestCase {
     

--- a/CopilotMonitor/CopilotMonitorTests/ClaudeProviderTests.swift
+++ b/CopilotMonitor/CopilotMonitorTests/ClaudeProviderTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import CopilotMonitor
+@testable import OpenCode_Bar
 
 final class ClaudeProviderTests: XCTestCase {
     

--- a/CopilotMonitor/CopilotMonitorTests/CodexProviderTests.swift
+++ b/CopilotMonitor/CopilotMonitorTests/CodexProviderTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import CopilotMonitor
+@testable import OpenCode_Bar
 
 final class CodexProviderTests: XCTestCase {
     

--- a/CopilotMonitor/CopilotMonitorTests/CopilotProviderTests.swift
+++ b/CopilotMonitor/CopilotMonitorTests/CopilotProviderTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import CopilotMonitor
+@testable import OpenCode_Bar
 
 final class CopilotProviderTests: XCTestCase {
     

--- a/CopilotMonitor/CopilotMonitorTests/DependencyTests.swift
+++ b/CopilotMonitor/CopilotMonitorTests/DependencyTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import CopilotMonitor
+@testable import OpenCode_Bar
 
 final class DependencyTests: XCTestCase {
     

--- a/CopilotMonitor/CopilotMonitorTests/GeminiCLIProviderTests.swift
+++ b/CopilotMonitor/CopilotMonitorTests/GeminiCLIProviderTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import CopilotMonitor
+@testable import OpenCode_Bar
 
 final class GeminiCLIProviderTests: XCTestCase {
     

--- a/CopilotMonitor/CopilotMonitorTests/MenuDesignTokenTests.swift
+++ b/CopilotMonitor/CopilotMonitorTests/MenuDesignTokenTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import CopilotMonitor
+@testable import OpenCode_Bar
 
 final class MenuDesignTokenTests: XCTestCase {
     func testDimensionValues() {

--- a/CopilotMonitor/CopilotMonitorTests/MenuResultBuilderTests.swift
+++ b/CopilotMonitor/CopilotMonitorTests/MenuResultBuilderTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable import CopilotMonitor
+@testable import OpenCode_Bar
 
 final class MenuResultBuilderTests: XCTestCase {
     

--- a/CopilotMonitor/CopilotMonitorTests/OpenRouterProviderTests.swift
+++ b/CopilotMonitor/CopilotMonitorTests/OpenRouterProviderTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import CopilotMonitor
+@testable import OpenCode_Bar
 
 final class OpenRouterProviderTests: XCTestCase {
     

--- a/CopilotMonitor/CopilotMonitorTests/ZaiCodingPlanProviderTests.swift
+++ b/CopilotMonitor/CopilotMonitorTests/ZaiCodingPlanProviderTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import CopilotMonitor
+@testable import OpenCode_Bar
 
 final class ZaiCodingPlanProviderTests: XCTestCase {
 

--- a/docs/AI_USAGE_API_REFERENCE.md
+++ b/docs/AI_USAGE_API_REFERENCE.md
@@ -1,6 +1,6 @@
 # AI Usage API Reference
 
-> OpenCode 사용자를 위한 AI 사용량 조회 API 레퍼런스
+> AI usage lookup API reference for OpenCode users
 
 ## Token Locations
 
@@ -36,8 +36,8 @@ curl -s "https://api.anthropic.com/api/oauth/usage" \
 
 | Field | Description |
 |-------|-------------|
-| `five_hour.utilization` | 5시간 윈도우 사용률 (%) |
-| `seven_day.utilization` | 7일 윈도우 사용률 (%) |
+| `five_hour.utilization` | 5-hour window utilization (%) |
+| `seven_day.utilization` | 7-day window utilization (%) |
 
 ---
 
@@ -74,8 +74,8 @@ curl -s "https://chatgpt.com/backend-api/wham/usage" \
 
 | Field | Description |
 |-------|-------------|
-| `primary_window.used_percent` | Primary rate limit 사용률 (%) |
-| `secondary_window.used_percent` | Secondary rate limit 사용률 (%) |
+| `primary_window.used_percent` | Primary rate limit utilization (%) |
+| `secondary_window.used_percent` | Secondary rate limit utilization (%) |
 
 ---
 
@@ -112,19 +112,19 @@ curl -s "https://api.github.com/copilot_internal/user" \
 
 | Field | Description |
 |-------|-------------|
-| `premium_interactions.entitlement` | 월간 프리미엄 요청 한도 |
-| `premium_interactions.remaining` | 남은 요청 수 (음수 = 초과) |
+| `premium_interactions.entitlement` | Monthly premium requests entitlement |
+| `premium_interactions.remaining` | Remaining requests (negative = overage) |
 
 ---
 
 ## 4. Antigravity (Dual Quota System)
 
-Antigravity는 **2개의 독립적인 쿼터 시스템**이 있습니다:
+Antigravity has **two independent quota systems**:
 
 | System | API | Models | Reset |
 |--------|-----|--------|-------|
-| **Gemini CLI** | `cloudcode-pa.googleapis.com` | gemini-2.0/2.5-flash/pro | ~17시간 |
-| **Antigravity Local** | Language Server (localhost) | Claude 4.5, Gemini 3, GPT-OSS | ~7일 |
+| **Gemini CLI** | `cloudcode-pa.googleapis.com` | gemini-2.0/2.5-flash/pro | ~17 hours |
+| **Antigravity Local** | Language Server (localhost) | Claude 4.5, Gemini 3, GPT-OSS | ~7 days |
 
 ### 4a. Gemini CLI Quota
 
@@ -290,7 +290,7 @@ Client Secret: Set GEMINI_CLIENT_SECRET environment variable
 
 ## Scripts
 
-테스트 스크립트는 `scripts/` 폴더에 있습니다:
+Test scripts are in the `scripts/` folder:
 
 | Script | Provider |
 |--------|----------|


### PR DESCRIPTION
## What
- Snapshot orphaned subscription keys before showing the reset confirmation to avoid auto-refresh races.
- Treat unknown provider subscription keys as orphaned when they contribute a non-zero cost, so stale entries can be cleaned up after provider renames/removals.
- Translate remaining Korean docs/comments to English.
- Fix tests to import the correct module and align Synthetic provider expectations.

## Why
Auto refresh can rebuild the menu while the reset alert is open, mutating the orphaned key list and causing resets to delete 0 (or the wrong) entries.

## How To Test
1. Ensure there is a stale/unknown subscription key with a non-zero cost (e.g. after a provider rename/removal).
2. Open the menu and confirm an `Orphaned ($12.34)` row appears.
3. Click `Orphaned` and confirm reset.
4. Verify via `/tmp/provider_debug.log` that keys were removed and the `Orphaned` row disappears.
