### PR TITLE
Add Codex Spark primary/weekly window grouping

### DIFF
--- a/CopilotMonitor/CopilotMonitor/App/StatusBarController.swift
+++ b/CopilotMonitor/CopilotMonitor/App/StatusBarController.swift
@@ -1004,7 +1004,7 @@ final class StatusBarController: NSObject {
                         // Build percentage array for display
                         // Claude: show 5h, 7d, and extra usage (if enabled)
                         // Kimi: show both 5h and 7d usage windows
-                        // Codex: show both primary (5h) and secondary (weekly) windows
+                        // Codex: show base primary/weekly plus Spark primary/weekly windows
                         // Z.AI: show both 5h token window and MCP usage
                         // Other providers: show single usage percentage
                         let usedPercents: [Double]
@@ -1025,9 +1025,18 @@ final class StatusBarController: NSObject {
                                   let fiveHour = account.details?.fiveHourUsage,
                                   let sevenDay = account.details?.sevenDayUsage {
                             usedPercents = [fiveHour, sevenDay]
-                        } else if identifier == .codex,
-                                  let secondary = account.details?.secondaryUsage {
-                            usedPercents = [account.usage.usagePercentage, secondary]
+                        } else if identifier == .codex {
+                            var percents = [account.usage.usagePercentage]
+                            if let secondary = account.details?.secondaryUsage {
+                                percents.append(secondary)
+                            }
+                            if let sparkPrimary = account.details?.sparkUsage {
+                                percents.append(sparkPrimary)
+                            }
+                            if let sparkSecondary = account.details?.sparkSecondaryUsage {
+                                percents.append(sparkSecondary)
+                            }
+                            usedPercents = percents
                         } else if identifier == .zaiCodingPlan {
                             let percents = [account.details?.tokenUsagePercent, account.details?.mcpUsagePercent].compactMap { $0 }
                             usedPercents = percents.isEmpty ? [account.usage.usagePercentage] : percents
@@ -1066,9 +1075,18 @@ final class StatusBarController: NSObject {
                               let fiveHour = result.details?.fiveHourUsage,
                               let sevenDay = result.details?.sevenDayUsage {
                         usedPercents = [fiveHour, sevenDay]
-                    } else if identifier == .codex,
-                              let secondary = result.details?.secondaryUsage {
-                        usedPercents = [singlePercent, secondary]
+                    } else if identifier == .codex {
+                        var percents = [singlePercent]
+                        if let secondary = result.details?.secondaryUsage {
+                            percents.append(secondary)
+                        }
+                        if let sparkPrimary = result.details?.sparkUsage {
+                            percents.append(sparkPrimary)
+                        }
+                        if let sparkSecondary = result.details?.sparkSecondaryUsage {
+                            percents.append(sparkSecondary)
+                        }
+                        usedPercents = percents
                     } else if identifier == .zaiCodingPlan {
                         let percents = [result.details?.tokenUsagePercent, result.details?.mcpUsagePercent].compactMap { $0 }
                         usedPercents = percents.isEmpty ? [singlePercent] : percents

--- a/CopilotMonitor/CopilotMonitor/Models/ProviderResult.swift
+++ b/CopilotMonitor/CopilotMonitor/Models/ProviderResult.swift
@@ -92,6 +92,11 @@ struct DetailedUsage {
     let secondaryUsage: Double?
     let secondaryReset: Date?
     let primaryReset: Date?
+    let sparkUsage: Double?
+    let sparkReset: Date?
+    let sparkSecondaryUsage: Double?
+    let sparkSecondaryReset: Date?
+    let sparkWindowLabel: String?
 
     // Codex/Antigravity plan info
     let creditsBalance: Double?
@@ -170,6 +175,11 @@ struct DetailedUsage {
         secondaryUsage: Double? = nil,
         secondaryReset: Date? = nil,
         primaryReset: Date? = nil,
+        sparkUsage: Double? = nil,
+        sparkReset: Date? = nil,
+        sparkSecondaryUsage: Double? = nil,
+        sparkSecondaryReset: Date? = nil,
+        sparkWindowLabel: String? = nil,
         creditsBalance: Double? = nil,
         planType: String? = nil,
         extraUsageEnabled: Bool? = nil,
@@ -227,6 +237,11 @@ struct DetailedUsage {
         self.secondaryUsage = secondaryUsage
         self.secondaryReset = secondaryReset
         self.primaryReset = primaryReset
+        self.sparkUsage = sparkUsage
+        self.sparkReset = sparkReset
+        self.sparkSecondaryUsage = sparkSecondaryUsage
+        self.sparkSecondaryReset = sparkSecondaryReset
+        self.sparkWindowLabel = sparkWindowLabel
         self.creditsBalance = creditsBalance
         self.planType = planType
         self.extraUsageEnabled = extraUsageEnabled
@@ -272,6 +287,7 @@ extension DetailedUsage: Codable {
         case fiveHourUsage, fiveHourReset, sevenDayUsage, sevenDayReset
         case sonnetUsage, sonnetReset, opusUsage, opusReset, modelBreakdown, modelResetTimes
         case secondaryUsage, secondaryReset, primaryReset
+        case sparkUsage, sparkReset, sparkSecondaryUsage, sparkSecondaryReset, sparkWindowLabel
         case creditsBalance, planType, extraUsageEnabled
         case extraUsageMonthlyLimitUSD, extraUsageUsedUSD, extraUsageUtilizationPercent
         case sessions, messages, avgCostPerDay, email
@@ -307,6 +323,11 @@ extension DetailedUsage: Codable {
         secondaryUsage = try container.decodeIfPresent(Double.self, forKey: .secondaryUsage)
         secondaryReset = try container.decodeIfPresent(Date.self, forKey: .secondaryReset)
         primaryReset = try container.decodeIfPresent(Date.self, forKey: .primaryReset)
+        sparkUsage = try container.decodeIfPresent(Double.self, forKey: .sparkUsage)
+        sparkReset = try container.decodeIfPresent(Date.self, forKey: .sparkReset)
+        sparkSecondaryUsage = try container.decodeIfPresent(Double.self, forKey: .sparkSecondaryUsage)
+        sparkSecondaryReset = try container.decodeIfPresent(Date.self, forKey: .sparkSecondaryReset)
+        sparkWindowLabel = try container.decodeIfPresent(String.self, forKey: .sparkWindowLabel)
         creditsBalance = try container.decodeIfPresent(Double.self, forKey: .creditsBalance)
         planType = try container.decodeIfPresent(String.self, forKey: .planType)
         extraUsageEnabled = try container.decodeIfPresent(Bool.self, forKey: .extraUsageEnabled)
@@ -367,6 +388,11 @@ extension DetailedUsage: Codable {
         try container.encodeIfPresent(secondaryUsage, forKey: .secondaryUsage)
         try container.encodeIfPresent(secondaryReset, forKey: .secondaryReset)
         try container.encodeIfPresent(primaryReset, forKey: .primaryReset)
+        try container.encodeIfPresent(sparkUsage, forKey: .sparkUsage)
+        try container.encodeIfPresent(sparkReset, forKey: .sparkReset)
+        try container.encodeIfPresent(sparkSecondaryUsage, forKey: .sparkSecondaryUsage)
+        try container.encodeIfPresent(sparkSecondaryReset, forKey: .sparkSecondaryReset)
+        try container.encodeIfPresent(sparkWindowLabel, forKey: .sparkWindowLabel)
         try container.encodeIfPresent(creditsBalance, forKey: .creditsBalance)
         try container.encodeIfPresent(planType, forKey: .planType)
         try container.encodeIfPresent(extraUsageEnabled, forKey: .extraUsageEnabled)
@@ -483,6 +509,7 @@ extension DetailedUsage {
             || opusUsage != nil || opusReset != nil
             || modelBreakdown != nil || modelResetTimes != nil
             || secondaryUsage != nil || secondaryReset != nil || primaryReset != nil
+            || sparkUsage != nil || sparkReset != nil || sparkSecondaryUsage != nil || sparkSecondaryReset != nil || sparkWindowLabel != nil
             || creditsBalance != nil || planType != nil
             || extraUsageEnabled != nil
             || extraUsageMonthlyLimitUSD != nil || extraUsageUsedUSD != nil || extraUsageUtilizationPercent != nil

--- a/CopilotMonitor/CopilotMonitorTests/CodexProviderTests.swift
+++ b/CopilotMonitor/CopilotMonitorTests/CodexProviderTests.swift
@@ -46,11 +46,35 @@ final class CodexProviderTests: XCTestCase {
         
         let usedPercent = primaryWindow["used_percent"] as? Double
         let resetAfterSeconds = primaryWindow["reset_after_seconds"] as? Int
+
+        guard let additionalRateLimits = dict["additional_rate_limits"] as? [[String: Any]],
+              let sparkLimit = additionalRateLimits.first,
+              let sparkLimitName = sparkLimit["limit_name"] as? String,
+              let sparkRateLimit = sparkLimit["rate_limit"] as? [String: Any],
+              let sparkPrimary = sparkRateLimit["primary_window"] as? [String: Any],
+              let sparkSecondary = sparkRateLimit["secondary_window"] as? [String: Any] else {
+            XCTFail("additional_rate_limits[0].rate_limit.{primary_window,secondary_window} should exist")
+            return
+        }
+
+        let sparkUsedPercent = sparkPrimary["used_percent"] as? Double ?? (sparkPrimary["used_percent"] as? Int).flatMap { Double($0) }
+        let sparkResetAfterSeconds = sparkPrimary["reset_after_seconds"] as? Int
+        let sparkSecondaryUsedPercent = sparkSecondary["used_percent"] as? Double ?? (sparkSecondary["used_percent"] as? Int).flatMap { Double($0) }
+        let sparkSecondaryResetAfterSeconds = sparkSecondary["reset_after_seconds"] as? Int
         
         XCTAssertNotNil(usedPercent)
         XCTAssertNotNil(resetAfterSeconds)
         XCTAssertEqual(usedPercent, 9.0)
         XCTAssertEqual(resetAfterSeconds, 7252)
+        XCTAssertEqual(sparkLimitName, "GPT-5.3-Codex-Spark")
+        XCTAssertNotNil(sparkUsedPercent)
+        XCTAssertNotNil(sparkResetAfterSeconds)
+        XCTAssertEqual(sparkUsedPercent, 16.0)
+        XCTAssertEqual(sparkResetAfterSeconds, 16711)
+        XCTAssertNotNil(sparkSecondaryUsedPercent)
+        XCTAssertNotNil(sparkSecondaryResetAfterSeconds)
+        XCTAssertEqual(sparkSecondaryUsedPercent, 5.0)
+        XCTAssertEqual(sparkSecondaryResetAfterSeconds, 603511)
     }
     
     func testProviderUsageQuotaBasedModel() {

--- a/CopilotMonitor/CopilotMonitorTests/Fixtures/codex_response.json
+++ b/CopilotMonitor/CopilotMonitorTests/Fixtures/codex_response.json
@@ -10,6 +10,22 @@
       "reset_after_seconds": 265266
     }
   },
+  "additional_rate_limits": [
+    {
+      "limit_name": "GPT-5.3-Codex-Spark",
+      "metered_feature": "codex_bengalfox",
+      "rate_limit": {
+        "primary_window": {
+          "used_percent": 16,
+          "reset_after_seconds": 16711
+        },
+        "secondary_window": {
+          "used_percent": 5,
+          "reset_after_seconds": 603511
+        }
+      }
+    }
+  ],
   "credits": {
     "balance": "0",
     "unlimited": false

--- a/docs/AI_USAGE_API_REFERENCE.md
+++ b/docs/AI_USAGE_API_REFERENCE.md
@@ -77,6 +77,22 @@ curl -s "https://chatgpt.com/backend-api/wham/usage" \
       "reset_after_seconds": 265266
     }
   },
+  "additional_rate_limits": [
+    {
+      "limit_name": "GPT-5.3-Codex-Spark",
+      "metered_feature": "codex_bengalfox",
+      "rate_limit": {
+        "primary_window": {
+          "used_percent": 16,
+          "reset_after_seconds": 16711
+        },
+        "secondary_window": {
+          "used_percent": 5,
+          "reset_after_seconds": 603511
+        }
+      }
+    }
+  ],
   "credits": { "balance": "0", "unlimited": false }
 }
 ```
@@ -85,6 +101,9 @@ curl -s "https://chatgpt.com/backend-api/wham/usage" \
 |-------|-------------|
 | `primary_window.used_percent` | Primary rate limit utilization (%) |
 | `secondary_window.used_percent` | Secondary rate limit utilization (%) |
+| `additional_rate_limits[].limit_name` | Additional quota limit display name (for example, Spark) |
+| `additional_rate_limits[].rate_limit.primary_window.used_percent` | Additional limit primary window utilization (%) |
+| `additional_rate_limits[].rate_limit.secondary_window.used_percent` | Additional limit secondary window utilization (%) |
 
 ---
 

--- a/scripts/query-codex-native.sh
+++ b/scripts/query-codex-native.sh
@@ -62,14 +62,42 @@ if echo "$RESPONSE" | jq -e '.detail' > /dev/null 2>&1; then
     exit 1
 fi
 
+echo "=== RAW Response ==="
+echo "$RESPONSE"
+
 echo "=== Usage Stats ==="
 echo "$RESPONSE" | jq '
+def spark_windows: (.rate_limit | to_entries | map(select(.key | test("spark"; "i"))));
+def additional_spark_limits: ((.additional_rate_limits // []) | map(select((.limit_name // "" | test("spark"; "i")) and (.rate_limit != null))));
+def spark_window_obj: (
+    if (spark_windows | length) > 0
+    then {"primary_window": (spark_windows | map(.value)[0]), "secondary_window": null}
+    elif (additional_spark_limits | length) > 0
+    then (additional_spark_limits[0].rate_limit // null)
+    else null
+    end
+);
+def spark_label: (
+    if (spark_windows | length) > 0
+    then (spark_windows | map(.key)[0] // null)
+    elif (additional_spark_limits | length) > 0
+    then (additional_spark_limits[0].limit_name // null)
+    else null
+    end
+);
 {
     "plan": .plan_type,
     "primary_used": (.rate_limit.primary_window.used_percent | tostring + "%"),
     "primary_reset_seconds": .rate_limit.primary_window.reset_after_seconds,
     "secondary_used": (.rate_limit.secondary_window.used_percent | tostring + "%"),
     "secondary_reset_seconds": .rate_limit.secondary_window.reset_after_seconds,
+    "spark_primary_used": ((spark_window_obj.primary_window.used_percent // null) | if . == null then null else tostring + "%" end),
+    "spark_primary_reset_seconds": (spark_window_obj.primary_window.reset_after_seconds // null),
+    "spark_secondary_used": ((spark_window_obj.secondary_window.used_percent // null) | if . == null then null else tostring + "%" end),
+    "spark_secondary_reset_seconds": (spark_window_obj.secondary_window.reset_after_seconds // null),
+    "spark_used": ((spark_window_obj.primary_window.used_percent // null) | if . == null then null else tostring + "%" end),
+    "spark_window": spark_label,
+    "spark_reset_seconds": (spark_window_obj.primary_window.reset_after_seconds // null),
     "credits_balance": .credits.balance,
     "credits_unlimited": .credits.unlimited
 }'


### PR DESCRIPTION
## Summary
- parse Codex Spark limits from `additional_rate_limits` with fallback support
- keep base Codex windows (5h, weekly) and add Spark windows as separate 5h/weekly group
- update top-level quota percent ordering to include base and Spark windows
- update Codex query scripts to expose Spark primary/secondary usage fields
- update fixture, tests, and API reference for `additional_rate_limits`

## Notes
- Spark title format changed to `period (model)` for readability
- left `default.profraw` unstaged/uncommitted intentionally