### PR TITLE
Fix Codex usage prediction display and window resolution

### DIFF
--- a/CopilotMonitor/CopilotMonitor/Helpers/ProviderMenuBuilder.swift
+++ b/CopilotMonitor/CopilotMonitor/Helpers/ProviderMenuBuilder.swift
@@ -1066,10 +1066,6 @@ extension StatusBarController {
         }
 
         var predictText: String {
-            if predictedFinalUsage > 100 {
-                let overagePercent = max(0.0, predictedFinalUsage - 100.0)
-                return String(format: "+%.0f%%", overagePercent)
-            }
             return String(format: "%.0f%%", predictedFinalUsage)
         }
     }


### PR DESCRIPTION
Summary
- simplify the predict text display so it always shows the raw predicted percent
- enhance Codex provider window resolution to prefer limit/reset data, handle multiple Spark windows, and improve logging
- normalize reset date resolution for different timestamp formats

Testing
- Not run (not requested)