### PR TITLE
Update Codex ChatGPT Business subscription pricing

### DIFF
--- a/CopilotMonitor/CopilotMonitor/Models/SubscriptionSettings.swift
+++ b/CopilotMonitor/CopilotMonitor/Models/SubscriptionSettings.swift
@@ -105,7 +105,7 @@ struct ProviderSubscriptionPresets {
     static let codex: [SubscriptionPreset] = [
         SubscriptionPreset(name: "Go", cost: 8),
         SubscriptionPreset(name: "Plus", cost: 20),
-        SubscriptionPreset(name: "Team", cost: 30),
+        SubscriptionPreset(name: "Business", cost: 25),
         SubscriptionPreset(name: "Pro", cost: 200)
     ]
 
@@ -228,7 +228,12 @@ final class SubscriptionSettingsManager {
               let plan = try? JSONDecoder().decode(SubscriptionPlan.self, from: data) else {
             return .none
         }
-        return plan
+        let normalizedPlan = normalizeLegacyPlan(plan, forKey: key)
+        if normalizedPlan != plan {
+            NSLog("Migrated legacy ChatGPT Team subscription preset to Business for key '%@'", fullKey)
+            setPlan(normalizedPlan, forKey: key)
+        }
+        return normalizedPlan
     }
 
     func getPlan(for provider: ProviderIdentifier, accountId: String? = nil) -> SubscriptionPlan {
@@ -283,5 +288,20 @@ final class SubscriptionSettingsManager {
             }
         }
         return false
+    }
+
+    private func normalizeLegacyPlan(_ plan: SubscriptionPlan, forKey key: String) -> SubscriptionPlan {
+        let isCodexSubscription = key == ProviderIdentifier.codex.rawValue
+            || key.hasPrefix("\(ProviderIdentifier.codex.rawValue).")
+        guard isCodexSubscription else {
+            return plan
+        }
+
+        guard case .preset(let name, _) = plan,
+              name.caseInsensitiveCompare("Team") == .orderedSame else {
+            return plan
+        }
+
+        return .preset("Business", 25)
     }
 }

--- a/CopilotMonitor/CopilotMonitorTests/ProviderUsageTests.swift
+++ b/CopilotMonitor/CopilotMonitorTests/ProviderUsageTests.swift
@@ -211,6 +211,26 @@ final class ProviderUsageTests: XCTestCase {
         XCTAssertTrue(output.contains("1%,1%"))
     }
 
+    func testCodexSubscriptionPresetsUseBusinessMonthlyPrice() {
+        let presets = ProviderSubscriptionPresets.presets(for: .codex)
+
+        XCTAssertTrue(presets.contains { $0.name == "Business" && $0.cost == 25 })
+        XCTAssertFalse(presets.contains { $0.name == "Team" })
+    }
+
+    func testSubscriptionSettingsMigratesLegacyCodexTeamPreset() {
+        let manager = SubscriptionSettingsManager.shared
+        let key = "codex.subscription-settings-migration-test"
+        defer { manager.removePlan(forKey: key) }
+
+        manager.setPlan(.preset("Team", 30), forKey: key)
+
+        let migratedPlan = manager.getPlan(forKey: key)
+
+        XCTAssertEqual(migratedPlan, .preset("Business", 25))
+        XCTAssertEqual(manager.getPlan(forKey: key), .preset("Business", 25))
+    }
+
     func testTableFormatterShowsGeminiPercentOnlyForGeminiAccounts() {
         let geminiAccounts = [
             GeminiAccountQuota(


### PR DESCRIPTION
## Summary
- rename the Codex subscription preset from Team to Business
- update the monthly price from $30 to $25 for the current ChatGPT Business monthly plan
- migrate persisted legacy Team presets to Business/$25 when they are read
- add regression coverage for the preset list and migration path

## Fact check
- OpenAI renamed ChatGPT Team to ChatGPT Business on August 29, 2025
- the rename announcement said pricing stayed the same at that time
- the current ChatGPT Business pricing is $25/user/month billed monthly and $20/user/month billed annually
- sources:
  - https://help.openai.com/en/articles/11391654-chatgpt-team-release-notes
  - https://help.openai.com/en/articles/8792828-what-is-chatgpt-team

## Testing
- Not run (per request)

Closes #125