### PR TITLE
Change the identifier of stored subscription information by account

### DIFF
--- a/CopilotMonitor/CopilotMonitor/App/StatusBarController.swift
+++ b/CopilotMonitor/CopilotMonitor/App/StatusBarController.swift
@@ -1377,6 +1377,20 @@ final class StatusBarController: NSObject {
         return ProviderIdentifier(rawValue: String(prefix))
     }
 
+    private func subscriptionAccountId(details: DetailedUsage?, fallback accountId: String? = nil) -> String? {
+        if let email = details?.email?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+           !email.isEmpty {
+            return email
+        }
+
+        if let accountId = accountId?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !accountId.isEmpty {
+            return accountId
+        }
+
+        return nil
+    }
+
     private func collectVisibleSubscriptionKeys(providerResults: [ProviderIdentifier: ProviderResult]) -> Set<String> {
         var keys = Set<String>()
 
@@ -1408,14 +1422,12 @@ final class StatusBarController: NSObject {
 
             if let accounts = result.accounts, !accounts.isEmpty {
                 for account in accounts {
-                    if let subId = account.subscriptionId, !subId.isEmpty {
-                        keys.insert(SubscriptionSettingsManager.shared.subscriptionKey(for: identifier, accountId: subId))
-                    } else {
-                        keys.insert(SubscriptionSettingsManager.shared.subscriptionKey(for: identifier))
-                    }
+                    let accountId = subscriptionAccountId(details: account.details, fallback: account.accountId)
+                    keys.insert(SubscriptionSettingsManager.shared.subscriptionKey(for: identifier, accountId: accountId))
                 }
             } else {
-                keys.insert(SubscriptionSettingsManager.shared.subscriptionKey(for: identifier))
+                let accountId = subscriptionAccountId(details: result.details)
+                keys.insert(SubscriptionSettingsManager.shared.subscriptionKey(for: identifier, accountId: accountId))
             }
         }
 
@@ -1826,7 +1838,8 @@ final class StatusBarController: NSObject {
                     )
                     submenu.addItem(authItem)
 
-                    addSubscriptionItems(to: submenu, provider: .copilot)
+                    let copilotSubscriptionAccountId = subscriptionAccountId(details: providerResults[.copilot]?.details)
+                    addSubscriptionItems(to: submenu, provider: .copilot, accountId: copilotSubscriptionAccountId)
 
                     quotaItem.submenu = submenu
                 }

--- a/CopilotMonitor/CopilotMonitor/Helpers/ProviderMenuBuilder.swift
+++ b/CopilotMonitor/CopilotMonitor/Helpers/ProviderMenuBuilder.swift
@@ -64,6 +64,7 @@ extension StatusBarController {
 
     func createDetailSubmenu(_ details: DetailedUsage, identifier: ProviderIdentifier, accountId: String? = nil) -> NSMenu {
         let submenu = NSMenu()
+        let subscriptionAccountId = resolvedSubscriptionAccountId(details: details, fallback: accountId)
 
         switch identifier {
         case .openRouter:
@@ -181,7 +182,7 @@ extension StatusBarController {
             submenu.addItem(authItem)
 
             // === Subscription ===
-            addSubscriptionItems(to: submenu, provider: .copilot, accountId: accountId)
+            addSubscriptionItems(to: submenu, provider: .copilot, accountId: subscriptionAccountId)
 
         case .claude:
             // === Usage Windows ===
@@ -287,7 +288,7 @@ extension StatusBarController {
             }
 
             // === Subscription (includes separator internally) ===
-            addSubscriptionItems(to: submenu, provider: .claude, accountId: accountId)
+            addSubscriptionItems(to: submenu, provider: .claude, accountId: subscriptionAccountId)
 
         case .codex:
             // === Usage Windows ===
@@ -379,7 +380,7 @@ extension StatusBarController {
             }
 
             // === Subscription ===
-            addSubscriptionItems(to: submenu, provider: .codex, accountId: accountId)
+            addSubscriptionItems(to: submenu, provider: .codex, accountId: subscriptionAccountId)
 
         case .cursor:
             var hasUsageWindow = false
@@ -408,7 +409,7 @@ extension StatusBarController {
                 submenu.addItem(item)
             }
 
-            addSubscriptionItems(to: submenu, provider: .cursor, accountId: accountId)
+            addSubscriptionItems(to: submenu, provider: .cursor, accountId: subscriptionAccountId)
 
         case .geminiCLI:
             // modelBreakdown stores remaining% — convert to used% at display layer
@@ -431,7 +432,7 @@ extension StatusBarController {
                 submenu.addItem(item)
             }
 
-            addSubscriptionItems(to: submenu, provider: .geminiCLI, accountId: details.email?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? accountId)
+            addSubscriptionItems(to: submenu, provider: .geminiCLI, accountId: subscriptionAccountId)
 
         case .antigravity:
             // modelBreakdown stores remaining% — convert to used% at display layer
@@ -456,7 +457,7 @@ extension StatusBarController {
                 createAccountInfoSection(items: accountItems).forEach { submenu.addItem($0) }
             }
 
-            addSubscriptionItems(to: submenu, provider: .antigravity, accountId: accountId)
+            addSubscriptionItems(to: submenu, provider: .antigravity, accountId: subscriptionAccountId)
 
         case .kimi:
             // === Usage Windows ===
@@ -491,7 +492,7 @@ extension StatusBarController {
             }
 
             // === Subscription ===
-            addSubscriptionItems(to: submenu, provider: .kimi, accountId: accountId)
+            addSubscriptionItems(to: submenu, provider: .kimi, accountId: subscriptionAccountId)
 
         case .minimaxCodingPlan:
             if let fiveHour = details.fiveHourUsage {
@@ -516,7 +517,7 @@ extension StatusBarController {
                 items.forEach { submenu.addItem($0) }
             }
 
-            addSubscriptionItems(to: submenu, provider: .minimaxCodingPlan, accountId: accountId)
+            addSubscriptionItems(to: submenu, provider: .minimaxCodingPlan, accountId: subscriptionAccountId)
 
         case .zaiCodingPlan:
             // === Token Usage ===
@@ -604,7 +605,7 @@ extension StatusBarController {
             }
 
             // === Subscription ===
-            addSubscriptionItems(to: submenu, provider: .zaiCodingPlan, accountId: accountId)
+            addSubscriptionItems(to: submenu, provider: .zaiCodingPlan, accountId: subscriptionAccountId)
 
         case .nanoGpt:
             if let weeklyUsage = details.sevenDayUsage {
@@ -633,7 +634,7 @@ extension StatusBarController {
                 submenu.addItem(item)
             }
 
-            addSubscriptionItems(to: submenu, provider: .nanoGpt, accountId: accountId)
+            addSubscriptionItems(to: submenu, provider: .nanoGpt, accountId: subscriptionAccountId)
 
         case .chutes:
             if let plan = details.planType {
@@ -681,7 +682,7 @@ extension StatusBarController {
             overageItem.view = createDisabledLabelView(text: "Overage: PAYGO after cap")
             submenu.addItem(overageItem)
 
-            addSubscriptionItems(to: submenu, provider: .chutes)
+            addSubscriptionItems(to: submenu, provider: .chutes, accountId: subscriptionAccountId)
 
         case .synthetic:
             if let fiveHour = details.fiveHourUsage {
@@ -702,7 +703,7 @@ extension StatusBarController {
                 submenu.addItem(item)
             }
             submenu.addItem(NSMenuItem.separator())
-            addSubscriptionItems(to: submenu, provider: .synthetic)
+            addSubscriptionItems(to: submenu, provider: .synthetic, accountId: subscriptionAccountId)
             debugLog("createDetailSubmenu: added subscription items for Synthetic")
 
         default:
@@ -788,6 +789,20 @@ extension StatusBarController {
         }
 
         return submenu
+    }
+
+    private func resolvedSubscriptionAccountId(details: DetailedUsage, fallback accountId: String?) -> String? {
+        if let email = details.email?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+           !email.isEmpty {
+            return email
+        }
+
+        if let accountId = accountId?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !accountId.isEmpty {
+            return accountId
+        }
+
+        return nil
     }
 
     private func addHorizontalDivider(to submenu: NSMenu) {
@@ -930,6 +945,8 @@ extension StatusBarController {
         let subscriptionKey = SubscriptionSettingsManager.shared.subscriptionKey(for: provider, accountId: accountId)
         let currentPlan = SubscriptionSettingsManager.shared.getPlan(forKey: subscriptionKey)
         let presets = ProviderSubscriptionPresets.presets(for: provider)
+        let subscriptionScope = subscriptionKey.hasSuffix(".\(SubscriptionSettingsManager.defaultAccountId)") ? "default" : "account"
+        debugLog("addSubscriptionItems: provider=\(provider.rawValue), subscriptionScope=\(subscriptionScope)")
 
         submenu.addItem(NSMenuItem.separator())
 

--- a/CopilotMonitor/CopilotMonitor/Models/SubscriptionSettings.swift
+++ b/CopilotMonitor/CopilotMonitor/Models/SubscriptionSettings.swift
@@ -217,30 +217,27 @@ struct ProviderSubscriptionPresets {
 
 final class SubscriptionSettingsManager {
     static let shared = SubscriptionSettingsManager()
+    static let defaultAccountId = "_default_"
 
     private let userDefaultsKeyPrefix = "subscription_v2."
 
     private init() {}
 
     func subscriptionKey(for provider: ProviderIdentifier, accountId: String? = nil) -> String {
-        if let accountId = accountId {
-            return "\(provider.rawValue).\(accountId)"
-        }
-        return provider.rawValue
+        "\(provider.rawValue).\(normalizedAccountId(accountId))"
     }
 
     func getPlan(forKey key: String) -> SubscriptionPlan {
+        guard isCurrentSubscriptionKey(key) else {
+            return .none
+        }
+
         let fullKey = "\(userDefaultsKeyPrefix)\(key)"
         guard let data = UserDefaults.standard.data(forKey: fullKey),
               let plan = try? JSONDecoder().decode(SubscriptionPlan.self, from: data) else {
             return .none
         }
-        let normalizedPlan = normalizeLegacyPlan(plan, forKey: key)
-        if normalizedPlan != plan {
-            NSLog("Migrated legacy ChatGPT Team subscription preset to Business for key '%@'", fullKey)
-            setPlan(normalizedPlan, forKey: key)
-        }
-        return normalizedPlan
+        return plan
     }
 
     func getPlan(for provider: ProviderIdentifier, accountId: String? = nil) -> SubscriptionPlan {
@@ -249,10 +246,16 @@ final class SubscriptionSettingsManager {
     }
 
     func setPlan(_ plan: SubscriptionPlan, forKey key: String) {
+        guard isCurrentSubscriptionKey(key) else {
+            NSLog("Skipped saving subscription plan for legacy key")
+            return
+        }
+
         let fullKey = "\(userDefaultsKeyPrefix)\(key)"
         do {
             let data = try JSONEncoder().encode(plan)
             UserDefaults.standard.set(data, forKey: fullKey)
+            NSLog("Saved subscription plan for account-scoped key")
         } catch {
             NSLog("Failed to encode SubscriptionPlan for key '%@': %@", fullKey, String(describing: error))
         }
@@ -278,6 +281,8 @@ final class SubscriptionSettingsManager {
         let allKeys = UserDefaults.standard.dictionaryRepresentation().keys
         return allKeys.filter { $0.hasPrefix(userDefaultsKeyPrefix) }
             .map { String($0.dropFirst(userDefaultsKeyPrefix.count)) }
+            .filter { isCurrentSubscriptionKey($0) }
+            .sorted()
     }
 
     func getTotalMonthlySubscriptionCost() -> Double {
@@ -297,18 +302,22 @@ final class SubscriptionSettingsManager {
         return false
     }
 
-    private func normalizeLegacyPlan(_ plan: SubscriptionPlan, forKey key: String) -> SubscriptionPlan {
-        let isCodexSubscription = key == ProviderIdentifier.codex.rawValue
-            || key.hasPrefix("\(ProviderIdentifier.codex.rawValue).")
-        guard isCodexSubscription else {
-            return plan
+    private func normalizedAccountId(_ accountId: String?) -> String {
+        guard let accountId = accountId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !accountId.isEmpty else {
+            return Self.defaultAccountId
+        }
+        return accountId.lowercased()
+    }
+
+    private func isCurrentSubscriptionKey(_ key: String) -> Bool {
+        let parts = key.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: false)
+        guard parts.count == 2,
+              ProviderIdentifier(rawValue: String(parts[0])) != nil else {
+            return false
         }
 
-        guard case .preset(let name, _) = plan,
-              name.caseInsensitiveCompare("Team") == .orderedSame else {
-            return plan
-        }
-
-        return .preset("Business", 25)
+        let accountId = String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return !accountId.isEmpty
     }
 }

--- a/CopilotMonitor/CopilotMonitorTests/ProviderUsageTests.swift
+++ b/CopilotMonitor/CopilotMonitorTests/ProviderUsageTests.swift
@@ -218,17 +218,37 @@ final class ProviderUsageTests: XCTestCase {
         XCTAssertFalse(presets.contains { $0.name == "Team" })
     }
 
-    func testSubscriptionSettingsMigratesLegacyCodexTeamPreset() {
+    func testSubscriptionSettingsUsesAccountScopedKeys() {
         let manager = SubscriptionSettingsManager.shared
-        let key = "codex.subscription-settings-migration-test"
-        defer { manager.removePlan(forKey: key) }
 
-        manager.setPlan(.preset("Team", 30), forKey: key)
+        XCTAssertEqual(manager.subscriptionKey(for: .claude), "claude._default_")
+        XCTAssertEqual(
+            manager.subscriptionKey(for: .claude, accountId: " User@Example.COM "),
+            "claude.user@example.com"
+        )
+    }
 
-        let migratedPlan = manager.getPlan(forKey: key)
+    func testSubscriptionSettingsIgnoresLegacyProviderLevelKeys() {
+        let manager = SubscriptionSettingsManager.shared
+        let validKey = manager.subscriptionKey(for: .codex, accountId: "subscription-settings-test@example.com")
+        let providerLevelKey = "codex"
+        let invalidProviderKey = "chatgpt.subscription-settings-test@example.com"
+        defer {
+            manager.removePlan(forKey: validKey)
+            manager.removePlan(forKey: providerLevelKey)
+            manager.removePlan(forKey: invalidProviderKey)
+        }
 
-        XCTAssertEqual(migratedPlan, .preset("Business", 25))
-        XCTAssertEqual(manager.getPlan(forKey: key), .preset("Business", 25))
+        manager.setPlan(.custom(11), forKey: validKey)
+        manager.setPlan(.custom(22), forKey: providerLevelKey)
+        manager.setPlan(.custom(33), forKey: invalidProviderKey)
+
+        XCTAssertEqual(manager.getPlan(forKey: validKey), .custom(11))
+        XCTAssertEqual(manager.getPlan(forKey: providerLevelKey), .none)
+        XCTAssertEqual(manager.getPlan(forKey: invalidProviderKey), .none)
+        XCTAssertTrue(manager.getAllSubscriptionKeys().contains(validKey))
+        XCTAssertFalse(manager.getAllSubscriptionKeys().contains(providerLevelKey))
+        XCTAssertFalse(manager.getAllSubscriptionKeys().contains(invalidProviderKey))
     }
 
     func testTableFormatterShowsGeminiPercentOnlyForGeminiAccounts() {


### PR DESCRIPTION
## Summary

- Store subscription settings under account-scoped keys in the form `subscription_v2.<provider>.<account>`.
- Use `_default_` when no email or stable account ID is available.
- Ignore legacy provider-level and invalid subscription keys instead of migrating them into current totals.
- Resolve subscription menu account IDs from email first, then account ID, then default scope.

## Impact

This prevents stale provider-level or malformed legacy subscription settings from being counted in monthly quota totals, while keeping account-specific subscription configuration available for multi-account providers.

## Validation

- `make setup`
- `xcodebuild test -project CopilotMonitor/CopilotMonitor.xcodeproj -scheme CopilotMonitor -destination 'platform=macOS' -only-testing:CopilotMonitorTests/ProviderUsageTests` - 27 tests passed
- `make lint-swift` - 0 violations
- Cleared DerivedData and rebuilt with `xcodebuild build -project CopilotMonitor/CopilotMonitor.xcodeproj -scheme CopilotMonitor -configuration Debug -destination 'platform=macOS'`
- Relaunched the Debug app and confirmed `/tmp/provider_debug.log` prints account/default subscription scope logs