### PR TITLE
Add OpenCode Go quota provider and status bar visibility policy

### DIFF
--- a/AGENTS-design-decisions.md
+++ b/AGENTS-design-decisions.md
@@ -62,6 +62,7 @@ Quit (⌘Q)
   - **GitHub Copilot** - Credits-based quotas with overage billing (Overage billing will be charged as `Add-on` in Pay-as-you-go)
   - **Gemini CLI** - Per-model quota limits
   - **Antigravity** - Local server monitoring by Antigravity IDE
+  - **OpenCode Go** - Time-window based quotas (5h/weekly/monthly)
   - **Z.AI Coding Plan** - Time-window based & tool usage based quotas
   - **Chutes AI** - Time-window based quotas, credits balance
 - **Features**

--- a/CopilotMonitor/CLI/CLIProviderManager.swift
+++ b/CopilotMonitor/CLI/CLIProviderManager.swift
@@ -14,7 +14,7 @@ actor CLIProviderManager {
     
     static let registeredProviders: [ProviderIdentifier] = [
         .claude, .codex, .cursor, .geminiCLI, .openRouter,
-        .antigravity, .openCodeZen, .kimi, .minimaxCodingPlan, .zaiCodingPlan,
+        .antigravity, .openCodeZen, .openCodeGo, .kimi, .minimaxCodingPlan, .zaiCodingPlan,
         .nanoGpt,
         .chutes, .copilot,
         .synthetic
@@ -32,6 +32,7 @@ actor CLIProviderManager {
         let openRouterProvider = OpenRouterProvider()
         let antigravityProvider = AntigravityProvider()
         let openCodeZenProvider = OpenCodeZenProvider()
+        let openCodeGoProvider = OpenCodeGoProvider()
         let kimiProvider = KimiProvider()
         let minimaxProvider = MiniMaxProvider()
         let zaiCodingPlanProvider = ZaiCodingPlanProvider()
@@ -50,6 +51,7 @@ actor CLIProviderManager {
             openRouterProvider,
             antigravityProvider,
             openCodeZenProvider,
+            openCodeGoProvider,
             kimiProvider,
             minimaxProvider,
             zaiCodingPlanProvider,

--- a/CopilotMonitor/CopilotMonitor.xcodeproj/project.pbxproj
+++ b/CopilotMonitor/CopilotMonitor.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		A454D8C22F30544900E355E3 /* MenuBarExtraAccess in Frameworks */ = {isa = PBXBuildFile; productRef = MBA2222222222222222222222 /* MenuBarExtraAccess */; };
 		A454D8C42F30548900E355E3 /* ZaiCodingPlanProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A454D8C32F30548900E355E3 /* ZaiCodingPlanProvider.swift */; };
 		MINIMAXAPP11111111111111 /* MiniMaxProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = MINIMAXFILE2222222222222 /* MiniMaxProvider.swift */; };
+		OCGOAPP11111111111111 /* OpenCodeGoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OCGOFILE2222222222222 /* OpenCodeGoProvider.swift */; };
 		NANOGPTAPP11111111111111 /* NanoGptProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = NANOGPTFILE222222222222 /* NanoGptProvider.swift */; };
 		A55555555555555555555555 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A66666666666666666666666 /* Assets.xcassets */; };
 		AD95EBD6AE3134DF4C797577 /* ClaudeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDC1B4DE6B5118CE4AE8F82 /* ClaudeProvider.swift */; };
@@ -55,6 +56,7 @@
 		CLIHISTORY11111111111111 /* CopilotHistoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1085A77EF4A58E5B5EC71B /* CopilotHistoryService.swift */; };
 		CLIKIMI1111111111111111 /* KimiProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = KI2222222222222222222222 /* KimiProvider.swift */; };
 		CLIMINIMAX11111111111111 /* MiniMaxProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = MINIMAXFILE2222222222222 /* MiniMaxProvider.swift */; };
+		OCGOCLI11111111111111 /* OpenCodeGoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OCGOFILE2222222222222 /* OpenCodeGoProvider.swift */; };
 		CLIZAI11111111111111111 /* ZaiCodingPlanProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A454D8C32F30548900E355E3 /* ZaiCodingPlanProvider.swift */; };
 		NANOGPTCLI11111111111111 /* NanoGptProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = NANOGPTFILE222222222222 /* NanoGptProvider.swift */; };
 		CLIOPENCZEN1111111111111 /* OpenCodeZenProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OZ2222222222222222222222 /* OpenCodeZenProvider.swift */; };
@@ -71,6 +73,7 @@
 		F35960B456C28D71BE7575A5 /* GeminiCLIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06EC3B683EB6892E4F9C8316 /* GeminiCLIProvider.swift */; };
 		KI1111111111111111111111 /* KimiProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = KI2222222222222222222222 /* KimiProvider.swift */; };
 		MINIMAXTESTBF11111111111 /* MiniMaxProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MINIMAXTESTFR11111111111 /* MiniMaxProviderTests.swift */; };
+		OCGOTESTBF11111111111 /* OpenCodeGoProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OCGOTESTFR11111111111 /* OpenCodeGoProviderTests.swift */; };
 		MINIMAXJSONBF11111111111 /* minimax_response.json in Resources */ = {isa = PBXBuildFile; fileRef = MINIMAXJSONFR11111111111 /* minimax_response.json */; };
 		BRAVEAPP1111111111111111 /* BraveSearchProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BRAVEFILE22222222222222 /* BraveSearchProvider.swift */; };
 		TAVILYAPP111111111111111 /* TavilySearchProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = TAVILYFILE22222222222222 /* TavilySearchProvider.swift */; };
@@ -162,6 +165,7 @@
 		A44444444444444444444444 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A454D8C32F30548900E355E3 /* ZaiCodingPlanProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZaiCodingPlanProvider.swift; sourceTree = "<group>"; };
 		MINIMAXFILE2222222222222 /* MiniMaxProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniMaxProvider.swift; sourceTree = "<group>"; };
+		OCGOFILE2222222222222 /* OpenCodeGoProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeGoProvider.swift; sourceTree = "<group>"; };
 		NANOGPTFILE222222222222 /* NanoGptProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NanoGptProvider.swift; sourceTree = "<group>"; };
 		A66666666666666666666666 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A77777777777777777777777 /* OpenCode Bar.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "OpenCode Bar.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -189,6 +193,7 @@
 		F4AE672516E564CC52739BD9 /* CopilotProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CopilotProvider.swift; sourceTree = "<group>"; };
 		KI2222222222222222222222 /* KimiProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KimiProvider.swift; sourceTree = "<group>"; };
 		MINIMAXTESTFR11111111111 /* MiniMaxProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniMaxProviderTests.swift; sourceTree = "<group>"; };
+		OCGOTESTFR11111111111 /* OpenCodeGoProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeGoProviderTests.swift; sourceTree = "<group>"; };
 		MINIMAXJSONFR11111111111 /* minimax_response.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = minimax_response.json; sourceTree = "<group>"; };
 		BRAVEFILE22222222222222 /* BraveSearchProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveSearchProvider.swift; sourceTree = "<group>"; };
 		TAVILYFILE22222222222222 /* TavilySearchProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TavilySearchProvider.swift; sourceTree = "<group>"; };
@@ -275,6 +280,7 @@
 				OR2222222222222222222222 /* OpenRouterProvider.swift */,
 				F1DA8E47F4CFEFC3571708AD /* AntigravityProvider.swift */,
 				OZ2222222222222222222222 /* OpenCodeZenProvider.swift */,
+				OCGOFILE2222222222222 /* OpenCodeGoProvider.swift */,
 				KI2222222222222222222222 /* KimiProvider.swift */,
 				MINIMAXFILE2222222222222 /* MiniMaxProvider.swift */,
 				283349002F313176004DADE1 /* ChutesProvider.swift */,
@@ -427,6 +433,7 @@
 				SYNTHTEST1111111111111111 /* SyntheticProviderTests.swift */,
 				NANOGPTTESTFR1111111111 /* NanoGptProviderTests.swift */,
 				MINIMAXTESTFR11111111111 /* MiniMaxProviderTests.swift */,
+				OCGOTESTFR11111111111 /* OpenCodeGoProviderTests.swift */,
 				CURSORTSTFR11111111111 /* CursorProviderTests.swift */,
 				TOKENTESTFR1111111111111 /* TokenManagerTests.swift */,
 				CODEXTESTFR111111111111 /* CodexProviderTests.swift */,
@@ -599,6 +606,7 @@
 			CLIOPENCZEN1111111111111 /* OpenCodeZenProvider.swift in Sources */,
 			CLIKIMI1111111111111111 /* KimiProvider.swift in Sources */,
 			CLIMINIMAX11111111111111 /* MiniMaxProvider.swift in Sources */,
+			OCGOCLI11111111111111 /* OpenCodeGoProvider.swift in Sources */,
 			CLIZAI11111111111111111 /* ZaiCodingPlanProvider.swift in Sources */,
 			NANOGPTCLI11111111111111 /* NanoGptProvider.swift in Sources */,
 			283349022F313176004DADE1 /* ChutesProvider.swift in Sources */,
@@ -643,6 +651,7 @@
 				OZ1111111111111111111111 /* OpenCodeZenProvider.swift in Sources */,
 				KI1111111111111111111111 /* KimiProvider.swift in Sources */,
 				MINIMAXAPP11111111111111 /* MiniMaxProvider.swift in Sources */,
+				OCGOAPP11111111111111 /* OpenCodeGoProvider.swift in Sources */,
 				283349012F313176004DADE1 /* ChutesProvider.swift in Sources */,
 				TAVILYAPP111111111111111 /* TavilySearchProvider.swift in Sources */,
 				BRAVEAPP1111111111111111 /* BraveSearchProvider.swift in Sources */,
@@ -673,6 +682,7 @@
 			SYNTHTEST2222222222222222 /* SyntheticProviderTests.swift in Sources */,
 			NANOGPTTESTBF1111111111 /* NanoGptProviderTests.swift in Sources */,
 			MINIMAXTESTBF11111111111 /* MiniMaxProviderTests.swift in Sources */,
+			OCGOTESTBF11111111111 /* OpenCodeGoProviderTests.swift in Sources */,
 			CURSORTSTBF11111111111 /* CursorProviderTests.swift in Sources */,
 			TOKENTESTBF1111111111111 /* TokenManagerTests.swift in Sources */,
 			CODEXTESTBF111111111111 /* CodexProviderTests.swift in Sources */,

--- a/CopilotMonitor/CopilotMonitor/App/StatusBarController.swift
+++ b/CopilotMonitor/CopilotMonitor/App/StatusBarController.swift
@@ -894,10 +894,25 @@ final class StatusBarController: NSObject {
     }
 
     private func selectedPinnedProvider() -> ProviderIdentifier? {
+        let visibleQuotaProviderIds = Set(
+            quotaAlertCandidates(logContext: menuBarDisplayProvider == nil ? "pinned-provider-auto" : "pinned-provider").map(\.identifier)
+        )
         if let selected = menuBarDisplayProvider {
             // If user explicitly pinned a provider but it's disabled, return nil
             // so the UI falls back to Total Cost instead of silently switching providers
-            return isProviderEnabled(selected) ? selected : nil
+            guard isProviderEnabled(selected) else { return nil }
+            if let result = providerResults[selected],
+               case .quotaBased = result.usage,
+               !visibleQuotaProviderIds.contains(selected) {
+                debugLog("selectedPinnedProvider: hiding pinned \(selected.displayName) because exhausted while other quota remains")
+                return nil
+            }
+            return selected
+        }
+        if let quotaProvider = ProviderIdentifier.allCases.first(where: {
+            visibleQuotaProviderIds.contains($0) && isProviderEnabled($0)
+        }) {
+            return quotaProvider
         }
         return ProviderIdentifier.allCases.first(where: { isProviderEnabled($0) })
     }
@@ -966,6 +981,10 @@ final class StatusBarController: NSObject {
             add(details?.sevenDayUsage, priority: .weekly)
             add(details?.fiveHourUsage, priority: .hourly)
         case .minimaxCodingPlan:
+            add(details?.sevenDayUsage, priority: .weekly)
+            add(details?.fiveHourUsage, priority: .hourly)
+        case .openCodeGo:
+            add(details?.openCodeGoMonthlyUsage, priority: .monthly)
             add(details?.sevenDayUsage, priority: .weekly)
             add(details?.fiveHourUsage, priority: .hourly)
         case .codex:
@@ -1098,7 +1117,8 @@ final class StatusBarController: NSObject {
                     details.cursorAutoUsage,
                     details.cursorApiUsage,
                     details.tokenUsagePercent,
-                    details.mcpUsagePercent
+                    details.mcpUsagePercent,
+                    details.openCodeGoMonthlyUsage
                 ]
                 for percent in extraPercents {
                     if let normalized = normalizedUsagePercent(percent) {
@@ -1152,6 +1172,9 @@ final class StatusBarController: NSObject {
             guard let snapshot = statusSnapshot(for: identifier, result: result) else { continue }
             currentSnapshots[identifier] = snapshot
         }
+        let visibleQuotaIdentifiers = Set(
+            quotaAlertCandidates(logContext: "recent-change").map(\.identifier)
+        )
 
         guard !currentSnapshots.isEmpty else {
             previousProviderSnapshots = [:]
@@ -1167,15 +1190,22 @@ final class StatusBarController: NSObject {
         }
 
         if currentSnapshots == previousProviderSnapshots {
-            if let existing = recentChangeCandidate, currentSnapshots[existing.identifier] == nil {
+            if let existing = recentChangeCandidate,
+               currentSnapshots[existing.identifier] == nil || !visibleQuotaIdentifiers.contains(existing.identifier) {
                 recentChangeCandidate = nil
+                debugLog("refreshRecentChangeCandidate: cleared hidden or missing candidate")
+            } else {
+                debugLog("refreshRecentChangeCandidate: snapshots unchanged, keeping previous candidate")
             }
-            debugLog("refreshRecentChangeCandidate: snapshots unchanged, keeping previous candidate")
             return
         }
 
         var bestCandidate: RecentChangeCandidate?
         for (identifier, newSnapshot) in currentSnapshots {
+            guard visibleQuotaIdentifiers.contains(identifier) else {
+                debugLog("refreshRecentChangeCandidate: skipping \(identifier.displayName) because exhausted while other quota remains")
+                continue
+            }
             guard let oldSnapshot = previousProviderSnapshots[identifier],
                   oldSnapshot.kind == newSnapshot.kind else {
                 continue
@@ -1197,22 +1227,28 @@ final class StatusBarController: NSObject {
         }
 
         previousProviderSnapshots = currentSnapshots
+        var didClearExistingCandidate = false
         if let bestCandidate {
             recentChangeCandidate = bestCandidate
-        } else if let existing = recentChangeCandidate, currentSnapshots[existing.identifier] == nil {
+        } else if let existing = recentChangeCandidate,
+                  currentSnapshots[existing.identifier] == nil || !visibleQuotaIdentifiers.contains(existing.identifier) {
             recentChangeCandidate = nil
+            didClearExistingCandidate = true
+            debugLog("refreshRecentChangeCandidate: cleared hidden or missing candidate after refresh")
         }
 
         if let bestCandidate {
             debugLog(
                 "refreshRecentChangeCandidate: provider=\(bestCandidate.identifier.displayName), kind=\(bestCandidate.kind), delta=\(String(format: "%.2f", bestCandidate.delta))"
             )
+        } else if didClearExistingCandidate {
+            debugLog("refreshRecentChangeCandidate: no significant change after clearing hidden candidate")
         } else {
             debugLog("refreshRecentChangeCandidate: no significant change, keeping previous candidate")
         }
     }
 
-    private func quotaAlertCandidates() -> [AlertProviderCandidate] {
+    private func rawQuotaAlertCandidates() -> [AlertProviderCandidate] {
         var candidates: [AlertProviderCandidate] = []
         for (identifier, result) in providerResults {
             guard isProviderEnabled(identifier) else { continue }
@@ -1223,14 +1259,48 @@ final class StatusBarController: NSObject {
         return candidates
     }
 
+    private func quotaAlertCandidates(logContext: String? = nil) -> [AlertProviderCandidate] {
+        let candidates = rawQuotaAlertCandidates()
+        let visibleCandidates = StatusBarQuotaVisibilityPolicy.visibleCandidates(
+            from: candidates,
+            usedPercent: { $0.usedPercent }
+        )
+        let allCandidatesExhausted = !candidates.isEmpty
+            && candidates.allSatisfy({ $0.usedPercent >= StatusBarQuotaVisibilityPolicy.exhaustedUsageThreshold })
+
+        if let logContext, !candidates.isEmpty {
+            debugLog(
+                "statusBarQuotaVisibility[\(logContext)]: checked candidates=\(candidates.count), visible=\(visibleCandidates.count), allExhausted=\(allCandidatesExhausted)"
+            )
+        }
+
+        if let logContext, visibleCandidates.count != candidates.count {
+            let visibleIdentifiers = Set(visibleCandidates.map(\.identifier))
+            let hiddenProviders = candidates
+                .filter { !visibleIdentifiers.contains($0.identifier) }
+                .map { "\($0.identifier.displayName)=\(UsagePercentDisplayFormatter.string(from: $0.usedPercent))" }
+                .joined(separator: ", ")
+            debugLog(
+                "statusBarQuotaVisibility[\(logContext)]: hiding exhausted providers while other quota remains: \(hiddenProviders)"
+            )
+        } else if let logContext,
+                  allCandidatesExhausted {
+            debugLog(
+                "statusBarQuotaVisibility[\(logContext)]: all quota providers exhausted; allowing exhausted provider display"
+            )
+        }
+
+        return visibleCandidates
+    }
+
     private func mostCriticalProvider(minUsagePercent: Double) -> AlertProviderCandidate? {
-        quotaAlertCandidates()
+        quotaAlertCandidates(logContext: "critical")
             .filter { $0.usedPercent >= minUsagePercent }
             .max(by: { $0.usedPercent < $1.usedPercent })
     }
 
     private func singleEnabledQuotaProvider(atOrAbove threshold: Double) -> AlertProviderCandidate? {
-        let candidates = quotaAlertCandidates()
+        let candidates = quotaAlertCandidates(logContext: "single-at-or-above")
         guard candidates.count == 1, let candidate = candidates.first, candidate.usedPercent >= threshold else {
             return nil
         }
@@ -1875,6 +1945,7 @@ final class StatusBarController: NSObject {
             .claude,
             .kimi,
             .minimaxCodingPlan,
+            .openCodeGo,
             .codex,
             .cursor,
             .zaiCodingPlan,
@@ -2014,6 +2085,13 @@ final class StatusBarController: NSObject {
                                   let fiveHour = account.details?.fiveHourUsage,
                                   let sevenDay = account.details?.sevenDayUsage {
                             usedPercents = [fiveHour, sevenDay]
+                        } else if identifier == .openCodeGo {
+                            let percents = [
+                                account.details?.fiveHourUsage,
+                                account.details?.sevenDayUsage,
+                                account.details?.openCodeGoMonthlyUsage
+                            ].compactMap { $0 }
+                            usedPercents = percents.isEmpty ? [account.usage.usagePercentage] : percents
                         } else if identifier == .kimi,
                                   let fiveHour = account.details?.fiveHourUsage,
                                   let sevenDay = account.details?.sevenDayUsage {
@@ -2087,6 +2165,13 @@ final class StatusBarController: NSObject {
                               let fiveHour = result.details?.fiveHourUsage,
                               let sevenDay = result.details?.sevenDayUsage {
                         usedPercents = [fiveHour, sevenDay]
+                    } else if identifier == .openCodeGo {
+                        let percents = [
+                            result.details?.fiveHourUsage,
+                            result.details?.sevenDayUsage,
+                            result.details?.openCodeGoMonthlyUsage
+                        ].compactMap { $0 }
+                        usedPercents = percents.isEmpty ? [singlePercent] : percents
                     } else if identifier == .kimi,
                               let fiveHour = result.details?.fiveHourUsage,
                               let sevenDay = result.details?.sevenDayUsage {
@@ -2940,6 +3025,8 @@ final class StatusBarController: NSObject {
         case .antigravity:
             image = NSImage(systemSymbolName: identifier.iconName, accessibilityDescription: identifier.displayName)
         case .openCodeZen:
+            image = NSImage(named: "OpencodeIcon")
+        case .openCodeGo:
             image = NSImage(named: "OpencodeIcon")
         case .kimi:
             image = NSImage(systemSymbolName: identifier.iconName, accessibilityDescription: identifier.displayName)
@@ -4104,6 +4191,20 @@ extension StatusBarController {
                     fiveHourReset: fiveHoursFromNow,
                     sevenDayUsage: 68.0,
                     sevenDayReset: sevenDaysFromNow,
+                    authSource: "OpenCode"
+                )
+            ),
+            .openCodeGo: ProviderResult(
+                usage: .quotaBased(remaining: 42, entitlement: 100, overagePermitted: false),
+                details: DetailedUsage(
+                    fiveHourUsage: 58.0,
+                    fiveHourReset: fiveHoursFromNow,
+                    sevenDayUsage: 41.0,
+                    sevenDayReset: sevenDaysFromNow,
+                    planType: "Go",
+                    openCodeGoMonthlyUsage: 24.0,
+                    openCodeGoMonthlyReset: sevenDaysFromNow,
+                    openCodeGoModelCount: 12,
                     authSource: "OpenCode"
                 )
             ),

--- a/CopilotMonitor/CopilotMonitor/Helpers/ProviderMenuBuilder.swift
+++ b/CopilotMonitor/CopilotMonitor/Helpers/ProviderMenuBuilder.swift
@@ -526,6 +526,57 @@ extension StatusBarController {
 
             addSubscriptionItems(to: submenu, provider: .minimaxCodingPlan, accountId: subscriptionAccountId)
 
+        case .openCodeGo:
+            if let fiveHour = details.fiveHourUsage {
+                let items = createUsageWindowRow(
+                    label: "5h",
+                    usagePercent: fiveHour,
+                    resetDate: details.fiveHourReset,
+                    windowHours: 5
+                )
+                items.forEach { submenu.addItem($0) }
+            }
+            if details.fiveHourUsage != nil, details.sevenDayUsage != nil {
+                submenu.addItem(NSMenuItem.separator())
+            }
+            if let weekly = details.sevenDayUsage {
+                let items = createUsageWindowRow(
+                    label: "Weekly",
+                    usagePercent: weekly,
+                    resetDate: details.sevenDayReset,
+                    windowHours: 168
+                )
+                items.forEach { submenu.addItem($0) }
+            }
+            if details.sevenDayUsage != nil, details.openCodeGoMonthlyUsage != nil {
+                submenu.addItem(NSMenuItem.separator())
+            }
+            if let monthly = details.openCodeGoMonthlyUsage {
+                let items = createUsageWindowRow(
+                    label: "Monthly",
+                    usagePercent: monthly,
+                    resetDate: details.openCodeGoMonthlyReset,
+                    isMonthly: true
+                )
+                items.forEach { submenu.addItem($0) }
+            }
+
+            if details.planType != nil || details.openCodeGoModelCount != nil {
+                submenu.addItem(NSMenuItem.separator())
+            }
+            if let plan = details.planType {
+                let item = NSMenuItem()
+                item.view = createDisabledLabelView(text: "Plan: \(plan)")
+                submenu.addItem(item)
+            }
+            if let modelCount = details.openCodeGoModelCount {
+                let item = NSMenuItem()
+                item.view = createDisabledLabelView(text: "Models: \(modelCount)")
+                submenu.addItem(item)
+            }
+
+            addSubscriptionItems(to: submenu, provider: .openCodeGo, accountId: subscriptionAccountId)
+
         case .zaiCodingPlan:
             // === Token Usage ===
             if let tokenUsage = details.tokenUsagePercent {

--- a/CopilotMonitor/CopilotMonitor/Models/ProviderProtocol.swift
+++ b/CopilotMonitor/CopilotMonitor/Models/ProviderProtocol.swift
@@ -19,6 +19,7 @@ enum ProviderIdentifier: String, CaseIterable {
     case openCode = "open_code"
     case antigravity
     case openCodeZen = "opencode_zen"
+    case openCodeGo = "opencode_go"
     case kimi
     case minimaxCodingPlan = "minimax_coding_plan"
     case zaiCodingPlan = "zai_coding_plan"
@@ -48,6 +49,8 @@ enum ProviderIdentifier: String, CaseIterable {
             return "Antigravity"
         case .openCodeZen:
             return "OpenCode Zen"
+        case .openCodeGo:
+            return "OpenCode Go"
         case .kimi:
             return "Kimi for Coding"
         case .minimaxCodingPlan:
@@ -87,6 +90,8 @@ enum ProviderIdentifier: String, CaseIterable {
             return "Google"
         case .openCodeZen:
             return "Zen"
+        case .openCodeGo:
+            return "Go"
         case .kimi:
             return "Kimi"
         case .minimaxCodingPlan:
@@ -126,6 +131,8 @@ enum ProviderIdentifier: String, CaseIterable {
             return "arrow.up.circle"
         case .openCodeZen:
             return "moon.stars"
+        case .openCodeGo:
+            return "chevron.left.forwardslash.chevron.right"
         case .kimi:
             return "k.circle"
         case .minimaxCodingPlan:

--- a/CopilotMonitor/CopilotMonitor/Models/ProviderResult.swift
+++ b/CopilotMonitor/CopilotMonitor/Models/ProviderResult.swift
@@ -18,6 +18,21 @@ enum UsagePercentDisplayFormatter {
     }
 }
 
+enum StatusBarQuotaVisibilityPolicy {
+    static let exhaustedUsageThreshold = 100.0
+
+    static func visibleCandidates<Candidate>(
+        from candidates: [Candidate],
+        usedPercent: (Candidate) -> Double
+    ) -> [Candidate] {
+        let candidatesWithQuotaLeft = candidates.filter {
+            usedPercent($0) < exhaustedUsageThreshold
+        }
+
+        return candidatesWithQuotaLeft.isEmpty ? candidates : candidatesWithQuotaLeft
+    }
+}
+
 struct ProviderResult {
     let usage: ProviderUsage
     let details: DetailedUsage?
@@ -145,6 +160,11 @@ struct DetailedUsage {
     let chutesMonthlyValueUsedUSD: Double?
     let chutesMonthlyValueUsedPercent: Double?
 
+    // OpenCode Go usage windows
+    let openCodeGoMonthlyUsage: Double?
+    let openCodeGoMonthlyReset: Date?
+    let openCodeGoModelCount: Int?
+
     // Claude extra usage toggle
     let extraUsageEnabled: Bool?
     // Claude extra usage (monthly credits limit + usage)
@@ -244,6 +264,9 @@ struct DetailedUsage {
         chutesMonthlyValueCapUSD: Double? = nil,
         chutesMonthlyValueUsedUSD: Double? = nil,
         chutesMonthlyValueUsedPercent: Double? = nil,
+        openCodeGoMonthlyUsage: Double? = nil,
+        openCodeGoMonthlyReset: Date? = nil,
+        openCodeGoModelCount: Int? = nil,
         extraUsageEnabled: Bool? = nil,
         extraUsageMonthlyLimitUSD: Double? = nil,
         extraUsageUsedUSD: Double? = nil,
@@ -322,6 +345,9 @@ struct DetailedUsage {
         self.chutesMonthlyValueCapUSD = chutesMonthlyValueCapUSD
         self.chutesMonthlyValueUsedUSD = chutesMonthlyValueUsedUSD
         self.chutesMonthlyValueUsedPercent = chutesMonthlyValueUsedPercent
+        self.openCodeGoMonthlyUsage = openCodeGoMonthlyUsage
+        self.openCodeGoMonthlyReset = openCodeGoMonthlyReset
+        self.openCodeGoModelCount = openCodeGoModelCount
         self.extraUsageEnabled = extraUsageEnabled
         self.extraUsageMonthlyLimitUSD = extraUsageMonthlyLimitUSD
         self.extraUsageUsedUSD = extraUsageUsedUSD
@@ -375,6 +401,7 @@ extension DetailedUsage: Codable {
         case sparkPrimaryWindowLabel, sparkPrimaryWindowHours, sparkSecondaryWindowLabel, sparkSecondaryWindowHours
         case creditsBalance, planType
         case chutesMonthlyValueCapUSD, chutesMonthlyValueUsedUSD, chutesMonthlyValueUsedPercent
+        case openCodeGoMonthlyUsage, openCodeGoMonthlyReset, openCodeGoModelCount
         case extraUsageEnabled
         case extraUsageMonthlyLimitUSD, extraUsageUsedUSD, extraUsageUtilizationPercent
         case sessions, messages, avgCostPerDay, email
@@ -429,6 +456,9 @@ extension DetailedUsage: Codable {
         chutesMonthlyValueCapUSD = try container.decodeIfPresent(Double.self, forKey: .chutesMonthlyValueCapUSD)
         chutesMonthlyValueUsedUSD = try container.decodeIfPresent(Double.self, forKey: .chutesMonthlyValueUsedUSD)
         chutesMonthlyValueUsedPercent = try container.decodeIfPresent(Double.self, forKey: .chutesMonthlyValueUsedPercent)
+        openCodeGoMonthlyUsage = try container.decodeIfPresent(Double.self, forKey: .openCodeGoMonthlyUsage)
+        openCodeGoMonthlyReset = try container.decodeIfPresent(Date.self, forKey: .openCodeGoMonthlyReset)
+        openCodeGoModelCount = try container.decodeIfPresent(Int.self, forKey: .openCodeGoModelCount)
         extraUsageEnabled = try container.decodeIfPresent(Bool.self, forKey: .extraUsageEnabled)
         extraUsageMonthlyLimitUSD = try container.decodeIfPresent(Double.self, forKey: .extraUsageMonthlyLimitUSD)
         extraUsageUsedUSD = try container.decodeIfPresent(Double.self, forKey: .extraUsageUsedUSD)
@@ -510,6 +540,9 @@ extension DetailedUsage: Codable {
         try container.encodeIfPresent(chutesMonthlyValueCapUSD, forKey: .chutesMonthlyValueCapUSD)
         try container.encodeIfPresent(chutesMonthlyValueUsedUSD, forKey: .chutesMonthlyValueUsedUSD)
         try container.encodeIfPresent(chutesMonthlyValueUsedPercent, forKey: .chutesMonthlyValueUsedPercent)
+        try container.encodeIfPresent(openCodeGoMonthlyUsage, forKey: .openCodeGoMonthlyUsage)
+        try container.encodeIfPresent(openCodeGoMonthlyReset, forKey: .openCodeGoMonthlyReset)
+        try container.encodeIfPresent(openCodeGoModelCount, forKey: .openCodeGoModelCount)
         try container.encodeIfPresent(extraUsageEnabled, forKey: .extraUsageEnabled)
         try container.encodeIfPresent(extraUsageMonthlyLimitUSD, forKey: .extraUsageMonthlyLimitUSD)
         try container.encodeIfPresent(extraUsageUsedUSD, forKey: .extraUsageUsedUSD)
@@ -602,6 +635,21 @@ struct JSONFormatter {
                 }
                 if let sevenDayUsage = result.details?.sevenDayUsage {
                     providerDict["sevenDayUsage"] = sevenDayUsage
+                }
+            }
+
+            if identifier == .openCodeGo {
+                if let fiveHourUsage = result.details?.fiveHourUsage {
+                    providerDict["fiveHourUsage"] = fiveHourUsage
+                }
+                if let sevenDayUsage = result.details?.sevenDayUsage {
+                    providerDict["sevenDayUsage"] = sevenDayUsage
+                }
+                if let monthlyUsage = result.details?.openCodeGoMonthlyUsage {
+                    providerDict["monthlyUsagePercent"] = monthlyUsage
+                }
+                if let modelCount = result.details?.openCodeGoModelCount {
+                    providerDict["modelCount"] = modelCount
                 }
             }
 
@@ -887,6 +935,16 @@ struct TableFormatter {
                     return percents.map { UsagePercentDisplayFormatter.string(from: $0) }.joined(separator: ",")
                 }
             }
+            if identifier == .openCodeGo {
+                let percents = [
+                    result.details?.fiveHourUsage,
+                    result.details?.sevenDayUsage,
+                    result.details?.openCodeGoMonthlyUsage
+                ].compactMap { $0 }
+                if percents.count >= 2 {
+                    return percents.map { UsagePercentDisplayFormatter.string(from: $0) }.joined(separator: ",")
+                }
+            }
             // Z.AI: show both token and MCP percentages when both are available
             if identifier == .zaiCodingPlan {
                 let percents = [result.details?.tokenUsagePercent, result.details?.mcpUsagePercent].compactMap { $0 }
@@ -1128,6 +1186,7 @@ extension DetailedUsage {
             || sparkUsage != nil || sparkReset != nil || sparkSecondaryUsage != nil || sparkSecondaryReset != nil || sparkWindowLabel != nil
             || creditsBalance != nil || planType != nil
             || chutesMonthlyValueCapUSD != nil || chutesMonthlyValueUsedUSD != nil || chutesMonthlyValueUsedPercent != nil
+            || openCodeGoMonthlyUsage != nil || openCodeGoMonthlyReset != nil || openCodeGoModelCount != nil
             || extraUsageEnabled != nil
             || extraUsageMonthlyLimitUSD != nil || extraUsageUsedUSD != nil || extraUsageUtilizationPercent != nil
             || sessions != nil || messages != nil || avgCostPerDay != nil

--- a/CopilotMonitor/CopilotMonitor/Models/SubscriptionSettings.swift
+++ b/CopilotMonitor/CopilotMonitor/Models/SubscriptionSettings.swift
@@ -172,6 +172,9 @@ struct ProviderSubscriptionPresets {
     static let openRouter: [SubscriptionPreset] = []
     static let openCode: [SubscriptionPreset] = []
     static let openCodeZen: [SubscriptionPreset] = []
+    static let openCodeGo: [SubscriptionPreset] = [
+        SubscriptionPreset(name: "Go", cost: 10)
+    ]
     static let tavilySearch: [SubscriptionPreset] = []
     static let braveSearch: [SubscriptionPreset] = []
 
@@ -199,6 +202,8 @@ struct ProviderSubscriptionPresets {
             return openCode
         case .openCodeZen:
             return openCodeZen
+        case .openCodeGo:
+            return openCodeGo
         case .tavilySearch:
             return tavilySearch
         case .braveSearch:

--- a/CopilotMonitor/CopilotMonitor/Providers/OpenCodeGoProvider.swift
+++ b/CopilotMonitor/CopilotMonitor/Providers/OpenCodeGoProvider.swift
@@ -17,6 +17,14 @@ struct OpenCodeGoDashboardUsage: Equatable {
     var usagePercents: [Double] {
         [rolling?.usagePercent, weekly?.usagePercent, monthly?.usagePercent].compactMap { $0 }
     }
+
+    var missingWindowNames: [String] {
+        var names: [String] = []
+        if rolling == nil { names.append("rollingUsage") }
+        if weekly == nil { names.append("weeklyUsage") }
+        if monthly == nil { names.append("monthlyUsage") }
+        return names
+    }
 }
 
 private struct OpenCodeGoDashboardCredentials {
@@ -61,7 +69,14 @@ final class OpenCodeGoProvider: ProviderProtocol {
         let (dashboardUsage, credentialSource) = try await fetchFirstDashboardUsage(from: credentialCandidates)
         guard !dashboardUsage.usagePercents.isEmpty else {
             logger.error("OpenCode Go dashboard response missing usage windows")
-            throw ProviderError.decodingError("Missing OpenCode Go dashboard usage windows")
+            throw ProviderError.decodingError(
+                "OpenCode Go dashboard markup may have changed. No usage windows were found. Please report this issue."
+            )
+        }
+
+        let missingWindowNames = dashboardUsage.missingWindowNames
+        if !missingWindowNames.isEmpty {
+            logger.warning("OpenCode Go dashboard missing usage window(s): \(missingWindowNames.joined(separator: ", "), privacy: .public)")
         }
 
         let overallUsed = dashboardUsage.usagePercents.max() ?? 0
@@ -104,7 +119,9 @@ final class OpenCodeGoProvider: ProviderProtocol {
         )
 
         guard !usage.usagePercents.isEmpty else {
-            throw ProviderError.decodingError("No OpenCode Go usage windows found in dashboard HTML")
+            throw ProviderError.decodingError(
+                "OpenCode Go dashboard markup may have changed. No usage windows were found. Please report this issue."
+            )
         }
 
         return usage

--- a/CopilotMonitor/CopilotMonitor/Providers/OpenCodeGoProvider.swift
+++ b/CopilotMonitor/CopilotMonitor/Providers/OpenCodeGoProvider.swift
@@ -1,0 +1,440 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.opencodeproviders", category: "OpenCodeGoProvider")
+
+struct OpenCodeGoUsageWindow: Equatable {
+    let usagePercent: Double
+    let resetInSeconds: Int
+    let resetDate: Date
+}
+
+struct OpenCodeGoDashboardUsage: Equatable {
+    let rolling: OpenCodeGoUsageWindow?
+    let weekly: OpenCodeGoUsageWindow?
+    let monthly: OpenCodeGoUsageWindow?
+
+    var usagePercents: [Double] {
+        [rolling?.usagePercent, weekly?.usagePercent, monthly?.usagePercent].compactMap { $0 }
+    }
+}
+
+private struct OpenCodeGoDashboardCredentials {
+    let workspaceID: String
+    let authCookie: String
+    let source: String
+}
+
+final class OpenCodeGoProvider: ProviderProtocol {
+    let identifier: ProviderIdentifier = .openCodeGo
+    let type: ProviderType = .quotaBased
+    let fetchTimeout: TimeInterval = 15
+    let minimumFetchInterval: TimeInterval = 60
+
+    private let tokenManager: TokenManager
+    private let session: URLSession
+    private let modelsURL = URL(string: "https://opencode.ai/zen/go/v1/models")!
+
+    init(tokenManager: TokenManager = .shared, session: URLSession = .shared) {
+        self.tokenManager = tokenManager
+        self.session = session
+    }
+
+    func fetch() async throws -> ProviderResult {
+        logger.info("OpenCode Go fetch started")
+
+        guard let apiKey = tokenManager.getOpenCodeGoAPIKey() else {
+            logger.error("OpenCode Go API key not found")
+            throw ProviderError.authenticationFailed("OpenCode Go API key not available")
+        }
+
+        let modelCount = try await fetchModelCount(apiKey: apiKey)
+
+        let credentialCandidates = dashboardCredentialCandidates()
+        guard !credentialCandidates.isEmpty else {
+            logger.warning("OpenCode Go dashboard usage setup is incomplete")
+            throw ProviderError.providerError(
+                "OpenCode Go dashboard usage setup is incomplete. Log in to opencode.ai in Chrome/Brave/Arc/Edge, visit the Go dashboard once, or set OPENCODE_GO_WORKSPACE_ID and OPENCODE_GO_AUTH_COOKIE."
+            )
+        }
+
+        let (dashboardUsage, credentialSource) = try await fetchFirstDashboardUsage(from: credentialCandidates)
+        guard !dashboardUsage.usagePercents.isEmpty else {
+            logger.error("OpenCode Go dashboard response missing usage windows")
+            throw ProviderError.decodingError("Missing OpenCode Go dashboard usage windows")
+        }
+
+        let overallUsed = dashboardUsage.usagePercents.max() ?? 0
+        let aggregateUsedPercent = UsagePercentDisplayFormatter.wholePercent(from: overallUsed)
+        let remainingPercent = max(0, 100 - aggregateUsedPercent)
+
+        let usage = ProviderUsage.quotaBased(
+            remaining: remainingPercent,
+            entitlement: 100,
+            overagePermitted: false
+        )
+
+        let authPath = tokenManager.lastFoundAuthPath?.path ?? "~/.local/share/opencode/auth.json"
+        let details = DetailedUsage(
+            fiveHourUsage: dashboardUsage.rolling?.usagePercent,
+            fiveHourReset: dashboardUsage.rolling?.resetDate,
+            sevenDayUsage: dashboardUsage.weekly?.usagePercent,
+            sevenDayReset: dashboardUsage.weekly?.resetDate,
+            planType: "Go",
+            openCodeGoMonthlyUsage: dashboardUsage.monthly?.usagePercent,
+            openCodeGoMonthlyReset: dashboardUsage.monthly?.resetDate,
+            openCodeGoModelCount: modelCount,
+            authSource: authPath,
+            authUsageSummary: credentialSource
+        )
+
+        logger.info(
+            "OpenCode Go usage fetched: 5h=\(dashboardUsage.rolling?.usagePercent.description ?? "n/a", privacy: .public)%, weekly=\(dashboardUsage.weekly?.usagePercent.description ?? "n/a", privacy: .public)%, monthly=\(dashboardUsage.monthly?.usagePercent.description ?? "n/a", privacy: .public)%"
+        )
+
+        return ProviderResult(usage: usage, details: details)
+    }
+
+    static func parseDashboardUsageHTML(_ html: String, now: Date = Date()) throws -> OpenCodeGoDashboardUsage {
+        let text = normalizedDashboardHTML(html)
+        let usage = OpenCodeGoDashboardUsage(
+            rolling: parseWindow(named: "rollingUsage", in: text, now: now),
+            weekly: parseWindow(named: "weeklyUsage", in: text, now: now),
+            monthly: parseWindow(named: "monthlyUsage", in: text, now: now)
+        )
+
+        guard !usage.usagePercents.isEmpty else {
+            throw ProviderError.decodingError("No OpenCode Go usage windows found in dashboard HTML")
+        }
+
+        return usage
+    }
+
+    private func fetchModelCount(apiKey: String) async throws -> Int {
+        var request = URLRequest(url: modelsURL)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let data = try await fetchData(request: request)
+        let object = try JSONSerialization.jsonObject(with: data)
+
+        if let dictionary = object as? [String: Any] {
+            if let dataArray = dictionary["data"] as? [Any] {
+                return dataArray.count
+            }
+            if let modelsArray = dictionary["models"] as? [Any] {
+                return modelsArray.count
+            }
+        }
+
+        if let array = object as? [Any] {
+            return array.count
+        }
+
+        throw ProviderError.decodingError("Unexpected OpenCode Go models response")
+    }
+
+    private func fetchDashboardUsage(credentials: OpenCodeGoDashboardCredentials) async throws -> OpenCodeGoDashboardUsage {
+        guard let url = URL(string: "https://opencode.ai/workspace/\(credentials.workspaceID)/go") else {
+            throw ProviderError.networkError("Invalid OpenCode Go workspace URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("text/html,application/xhtml+xml", forHTTPHeaderField: "Accept")
+        request.setValue(cookieHeader(from: credentials.authCookie), forHTTPHeaderField: "Cookie")
+        request.setValue(
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36",
+            forHTTPHeaderField: "User-Agent"
+        )
+
+        let data = try await fetchData(request: request)
+        guard let html = String(data: data, encoding: .utf8) else {
+            throw ProviderError.decodingError("OpenCode Go dashboard response is not UTF-8")
+        }
+
+        return try Self.parseDashboardUsageHTML(html)
+    }
+
+    private func fetchFirstDashboardUsage(
+        from candidates: [OpenCodeGoDashboardCredentials]
+    ) async throws -> (OpenCodeGoDashboardUsage, String) {
+        var lastError: Error?
+
+        for credentials in candidates {
+            do {
+                let usage = try await fetchDashboardUsage(credentials: credentials)
+                logger.info("OpenCode Go dashboard usage fetched from \(credentials.source, privacy: .public)")
+                return (usage, credentials.source)
+            } catch {
+                lastError = error
+                logger.warning("OpenCode Go dashboard candidate failed from \(credentials.source, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+        }
+
+        if let lastError {
+            throw lastError
+        }
+
+        throw ProviderError.providerError("No OpenCode Go dashboard credential candidates available")
+    }
+
+    private func fetchData(request: URLRequest) async throws -> Data {
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw ProviderError.networkError("Invalid response from OpenCode Go")
+            }
+
+            guard (200...299).contains(httpResponse.statusCode) else {
+                let message = errorMessage(from: data) ?? "HTTP \(httpResponse.statusCode)"
+                if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
+                    throw ProviderError.authenticationFailed(message)
+                }
+                throw ProviderError.networkError(message)
+            }
+
+            return data
+        } catch let error as ProviderError {
+            throw error
+        } catch {
+            throw ProviderError.networkError(error.localizedDescription)
+        }
+    }
+
+    private func errorMessage(from data: Data) -> String? {
+        guard !data.isEmpty else { return nil }
+        if let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            if let message = object["message"] as? String, !message.isEmpty {
+                return message
+            }
+            if let error = object["error"] as? String, !error.isEmpty {
+                return error
+            }
+            if let error = object["error"] as? [String: Any],
+               let message = error["message"] as? String,
+               !message.isEmpty {
+                return message
+            }
+        }
+        return String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func dashboardCredentialCandidates() -> [OpenCodeGoDashboardCredentials] {
+        var candidates: [OpenCodeGoDashboardCredentials] = []
+        var seen: Set<String> = []
+
+        func append(_ credentials: OpenCodeGoDashboardCredentials) {
+            let key = "\(credentials.workspaceID)::\(credentials.authCookie)"
+            guard !seen.contains(key) else { return }
+            seen.insert(key)
+            candidates.append(credentials)
+        }
+
+        let environment = ProcessInfo.processInfo.environment
+        if let workspaceID = nonEmpty(environment["OPENCODE_GO_WORKSPACE_ID"]),
+           let authCookie = nonEmpty(environment["OPENCODE_GO_AUTH_COOKIE"]) {
+            append(OpenCodeGoDashboardCredentials(
+                workspaceID: workspaceID,
+                authCookie: authCookie,
+                source: "Environment"
+            ))
+        }
+
+        for url in dashboardConfigURLs(environment: environment) {
+            guard let credentials = dashboardCredentials(from: url) else { continue }
+            append(credentials)
+        }
+
+        browserDashboardCredentialCandidates().forEach { append($0) }
+
+        return candidates
+    }
+
+    private func browserDashboardCredentialCandidates() -> [OpenCodeGoDashboardCredentials] {
+        do {
+            let cookies = try BrowserCookieService.shared.getCookies(hostSuffix: "opencode.ai", names: ["auth"])
+            let historyEntries = try BrowserCookieService.shared.getHistoryEntries(
+                hostSuffix: "opencode.ai",
+                pathPrefix: "/workspace/",
+                limit: 200
+            )
+            let cookiesByProfile = Dictionary(grouping: cookies, by: { $0.profileKey })
+            var candidates: [OpenCodeGoDashboardCredentials] = []
+
+            for entry in historyEntries {
+                guard let workspaceID = Self.extractWorkspaceID(from: entry.url.absoluteString) else {
+                    continue
+                }
+
+                let profileCookies = cookiesByProfile[entry.profileKey] ?? []
+                let fallbackCookies = cookies.filter { $0.profileKey != entry.profileKey }
+
+                for cookie in profileCookies + fallbackCookies {
+                    candidates.append(OpenCodeGoDashboardCredentials(
+                        workspaceID: workspaceID,
+                        authCookie: cookie.value,
+                        source: "Browser Cookies (\(cookie.displaySource))"
+                    ))
+                }
+            }
+
+            logger.info("OpenCode Go browser dashboard credential candidates: \(candidates.count)")
+            return candidates
+        } catch {
+            logger.warning("OpenCode Go browser dashboard credential discovery failed: \(error.localizedDescription, privacy: .public)")
+            return []
+        }
+    }
+
+    static func extractWorkspaceIDs(from urls: [String]) -> [String] {
+        guard let regex = try? NSRegularExpression(pattern: #"/workspace/(wrk_[A-Z0-9]+)"#) else {
+            return []
+        }
+
+        var workspaceIDs: [String] = []
+        var seen: Set<String> = []
+
+        for url in urls {
+            let range = NSRange(url.startIndex..<url.endIndex, in: url)
+            guard let match = regex.firstMatch(in: url, options: [], range: range),
+                  let valueRange = Range(match.range(at: 1), in: url) else {
+                continue
+            }
+            let workspaceID = String(url[valueRange])
+            guard !seen.contains(workspaceID) else { continue }
+            seen.insert(workspaceID)
+            workspaceIDs.append(workspaceID)
+        }
+
+        return workspaceIDs
+    }
+
+    private static func extractWorkspaceID(from url: String) -> String? {
+        extractWorkspaceIDs(from: [url]).first
+    }
+
+    private func dashboardConfigURLs(environment: [String: String]) -> [URL] {
+        var urls: [URL] = []
+
+        if let override = nonEmpty(environment["OPENCODE_GO_CONFIG_FILE"]) {
+            urls.append(URL(fileURLWithPath: NSString(string: override).expandingTildeInPath))
+        }
+
+        if let xdgConfigHome = nonEmpty(environment["XDG_CONFIG_HOME"]) {
+            let base = URL(fileURLWithPath: NSString(string: xdgConfigHome).expandingTildeInPath)
+            urls.append(base.appendingPathComponent("opencode-bar/opencode-go.json"))
+            urls.append(base.appendingPathComponent("opencode-quota/opencode-go.json"))
+        }
+
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        urls.append(home.appendingPathComponent(".config/opencode-bar/opencode-go.json"))
+        urls.append(home.appendingPathComponent(".config/opencode-quota/opencode-go.json"))
+        urls.append(home.appendingPathComponent("Library/Application Support/opencode-bar/opencode-go.json"))
+        urls.append(home.appendingPathComponent("Library/Application Support/opencode-quota/opencode-go.json"))
+
+        return urls
+    }
+
+    private func dashboardCredentials(from url: URL) -> OpenCodeGoDashboardCredentials? {
+        guard FileManager.default.isReadableFile(atPath: url.path),
+              let data = try? Data(contentsOf: url),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let workspaceID = nonEmptyString(from: object, keys: ["workspaceId", "workspaceID", "workspace_id"]),
+              let authCookie = nonEmptyString(from: object, keys: ["authCookie", "auth_cookie", "cookie"]) else {
+            return nil
+        }
+
+        return OpenCodeGoDashboardCredentials(
+            workspaceID: workspaceID,
+            authCookie: authCookie,
+            source: url.path
+        )
+    }
+
+    private func nonEmptyString(from object: [String: Any], keys: [String]) -> String? {
+        for key in keys {
+            if let value = object[key] as? String,
+               let normalized = nonEmpty(value) {
+                return normalized
+            }
+        }
+        return nil
+    }
+
+    private func cookieHeader(from rawValue: String) -> String {
+        if rawValue.contains("auth=") {
+            return rawValue
+        }
+        return "auth=\(rawValue)"
+    }
+
+    private func nonEmpty(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func parseWindow(named fieldName: String, in text: String, now: Date) -> OpenCodeGoUsageWindow? {
+        guard let body = captureObjectBody(named: fieldName, in: text),
+              let usagePercent = captureNumber(named: "usagePercent", in: body),
+              let resetInSecondsDouble = captureNumber(named: "resetInSec", in: body) else {
+            return nil
+        }
+
+        let resetInSeconds = max(0, Int(resetInSecondsDouble.rounded()))
+        return OpenCodeGoUsageWindow(
+            usagePercent: usagePercent,
+            resetInSeconds: resetInSeconds,
+            resetDate: now.addingTimeInterval(TimeInterval(resetInSeconds))
+        )
+    }
+
+    private static func captureObjectBody(named fieldName: String, in text: String) -> String? {
+        let pattern = #"["']?\#(NSRegularExpression.escapedPattern(for: fieldName))["']?\s*:\s*(?:\$R\[\d+\]\s*=\s*)?\{(?<body>[^{}]*)\}"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.dotMatchesLineSeparators]) else {
+            return nil
+        }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, options: [], range: range) else {
+            return nil
+        }
+        let bodyRange = match.range(withName: "body")
+        guard let swiftRange = Range(bodyRange, in: text) else {
+            return nil
+        }
+        return String(text[swiftRange])
+    }
+
+    private static func captureNumber(named fieldName: String, in text: String) -> Double? {
+        let pattern = #"["']?\#(NSRegularExpression.escapedPattern(for: fieldName))["']?\s*:\s*"?(-?\d+(?:\.\d+)?)"?"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return nil
+        }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, options: [], range: range),
+              let valueRange = Range(match.range(at: 1), in: text) else {
+            return nil
+        }
+        return Double(text[valueRange])
+    }
+
+    private static func normalizedDashboardHTML(_ html: String) -> String {
+        var text = html
+        let replacements = [
+            ("&quot;", "\""),
+            ("&#34;", "\""),
+            ("&#x27;", "'"),
+            ("&#39;", "'"),
+            ("&amp;", "&"),
+            (#"\""#, "\""),
+            (#"\u0022"#, "\"")
+        ]
+        for (encoded, decoded) in replacements {
+            text = text.replacingOccurrences(of: encoded, with: decoded)
+        }
+        return text
+    }
+}

--- a/CopilotMonitor/CopilotMonitor/Services/BrowserCookieService.swift
+++ b/CopilotMonitor/CopilotMonitor/Services/BrowserCookieService.swift
@@ -5,6 +5,7 @@ import CommonCrypto
 import os.log
 
 private let logger = Logger(subsystem: "com.opencodeproviders", category: "BrowserCookieService")
+private let sqliteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 
 /// Service for extracting and decrypting cookies from Chromium-based browsers.
 /// Supports Chrome, Brave, Arc, and Edge on macOS.
@@ -60,7 +61,9 @@ class BrowserCookieService {
 
     func getCookies(hostSuffix: String, names: Set<String>) throws -> [BrowserCookie] {
         var allCookies: [BrowserCookie] = []
-        let normalizedHost = hostSuffix.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let normalizedHost = normalizedDomainHost(hostSuffix) else {
+            throw BrowserCookieError.noBrowserFound
+        }
 
         for browser in SupportedBrowser.allCases {
             let paths = browser.cookieDBPaths
@@ -97,7 +100,9 @@ class BrowserCookieService {
 
     func getHistoryEntries(hostSuffix: String, pathPrefix: String, limit: Int = 100) throws -> [BrowserHistoryEntry] {
         var allEntries: [BrowserHistoryEntry] = []
-        let normalizedHost = hostSuffix.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let normalizedHost = normalizedDomainHost(hostSuffix) else {
+            throw BrowserCookieError.noBrowserFound
+        }
 
         for browser in SupportedBrowser.allCases {
             for cookieDBPath in browser.cookieDBPaths {
@@ -321,14 +326,28 @@ class BrowserCookieService {
         }
         defer { sqlite3_close(db) }
 
-        let escapedHost = hostSuffix.replacingOccurrences(of: "'", with: "''")
-        let query = "SELECT name, encrypted_value, value, host_key FROM cookies WHERE host_key LIKE '%\(escapedHost)%' ORDER BY expires_utc DESC"
+        let cookieNames = names.sorted()
+        let nameFilter = cookieNames.isEmpty
+            ? ""
+            : " AND name IN (\(cookieNames.map { _ in "?" }.joined(separator: ", ")))"
+        let query = """
+            SELECT name, encrypted_value, value, host_key
+            FROM cookies
+            WHERE (host_key = ? OR host_key LIKE ? ESCAPE '\\')\(nameFilter)
+            ORDER BY expires_utc DESC
+        """
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK else {
             logger.error("Failed to prepare generic cookie SQLite statement")
             throw BrowserCookieError.invalidCookieFormat
         }
         defer { sqlite3_finalize(statement) }
+
+        try bindText(hostSuffix, to: 1, in: statement, context: "cookie host")
+        try bindText("%.\(escapedLikeLiteral(hostSuffix))", to: 2, in: statement, context: "cookie host pattern")
+        for (offset, name) in cookieNames.enumerated() {
+            try bindText(name, to: Int32(offset + 3), in: statement, context: "cookie name")
+        }
 
         let dbURL = URL(fileURLWithPath: dbPath)
         let profileName = dbURL.deletingLastPathComponent().lastPathComponent
@@ -392,15 +411,18 @@ class BrowserCookieService {
         }
         defer { sqlite3_close(db) }
 
-        let escapedHost = hostSuffix.replacingOccurrences(of: "'", with: "''")
-        let escapedPrefix = pathPrefix.replacingOccurrences(of: "'", with: "''")
+        let escapedHost = escapedLikeLiteral(hostSuffix)
+        let escapedPrefix = escapedLikeLiteral(normalizedPathPrefix(pathPrefix))
         let cappedLimit = max(1, min(limit, 500))
         let query = """
             SELECT url, title, last_visit_time
             FROM urls
-            WHERE url LIKE 'http%://%\(escapedHost)\(escapedPrefix)%'
+            WHERE url LIKE ? ESCAPE '\\'
+               OR url LIKE ? ESCAPE '\\'
+               OR url LIKE ? ESCAPE '\\'
+               OR url LIKE ? ESCAPE '\\'
             ORDER BY last_visit_time DESC
-            LIMIT \(cappedLimit)
+            LIMIT ?
         """
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK else {
@@ -408,6 +430,20 @@ class BrowserCookieService {
             throw BrowserCookieError.invalidCookieFormat
         }
         defer { sqlite3_finalize(statement) }
+
+        let urlPatterns = [
+            "https://\(escapedHost)\(escapedPrefix)%",
+            "http://\(escapedHost)\(escapedPrefix)%",
+            "https://%.\(escapedHost)\(escapedPrefix)%",
+            "http://%.\(escapedHost)\(escapedPrefix)%"
+        ]
+        for (offset, pattern) in urlPatterns.enumerated() {
+            try bindText(pattern, to: Int32(offset + 1), in: statement, context: "history URL pattern")
+        }
+        guard sqlite3_bind_int(statement, 5, Int32(cappedLimit)) == SQLITE_OK else {
+            logger.error("Failed to bind browser history limit")
+            throw BrowserCookieError.invalidCookieFormat
+        }
 
         let dbURL = URL(fileURLWithPath: dbPath)
         let profileName = dbURL.deletingLastPathComponent().lastPathComponent
@@ -433,6 +469,40 @@ class BrowserCookieService {
         }
 
         return entries
+    }
+
+    private func normalizedDomainHost(_ host: String) -> String? {
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let withoutLeadingDot = trimmed.hasPrefix(".") ? String(trimmed.dropFirst()) : trimmed
+        return withoutLeadingDot.isEmpty ? nil : withoutLeadingDot
+    }
+
+    private func normalizedPathPrefix(_ pathPrefix: String) -> String {
+        let trimmed = pathPrefix.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "/" }
+        return trimmed.hasPrefix("/") ? trimmed : "/\(trimmed)"
+    }
+
+    private func escapedLikeLiteral(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "%", with: "\\%")
+            .replacingOccurrences(of: "_", with: "\\_")
+    }
+
+    private func bindText(
+        _ value: String,
+        to index: Int32,
+        in statement: OpaquePointer?,
+        context: String
+    ) throws {
+        let result = value.withCString {
+            sqlite3_bind_text(statement, index, $0, -1, sqliteTransient)
+        }
+        guard result == SQLITE_OK else {
+            logger.error("Failed to bind SQLite text value for \(context, privacy: .public)")
+            throw BrowserCookieError.invalidCookieFormat
+        }
     }
 
     // MARK: - AES-CBC Decryption

--- a/CopilotMonitor/CopilotMonitor/Services/BrowserCookieService.swift
+++ b/CopilotMonitor/CopilotMonitor/Services/BrowserCookieService.swift
@@ -6,7 +6,7 @@ import os.log
 
 private let logger = Logger(subsystem: "com.opencodeproviders", category: "BrowserCookieService")
 
-/// Service for extracting and decrypting GitHub cookies from Chromium-based browsers.
+/// Service for extracting and decrypting cookies from Chromium-based browsers.
 /// Supports Chrome, Brave, Arc, and Edge on macOS.
 /// Uses macOS Keychain for encryption key retrieval and PBKDF2 + AES-CBC for decryption.
 class BrowserCookieService {
@@ -56,6 +56,78 @@ class BrowserCookieService {
 
         debugLog("No browser found with valid GitHub cookies")
         throw BrowserCookieError.noBrowserFound
+    }
+
+    func getCookies(hostSuffix: String, names: Set<String>) throws -> [BrowserCookie] {
+        var allCookies: [BrowserCookie] = []
+        let normalizedHost = hostSuffix.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        for browser in SupportedBrowser.allCases {
+            let paths = browser.cookieDBPaths
+            guard !paths.isEmpty else { continue }
+
+            do {
+                let encryptionKey = try getEncryptionKey(for: browser)
+                let aesKey = try deriveAESKey(from: encryptionKey)
+
+                for path in paths {
+                    do {
+                        let cookies = try readBrowserCookies(
+                            from: path,
+                            aesKey: aesKey,
+                            hostSuffix: normalizedHost,
+                            names: names
+                        )
+                        allCookies.append(contentsOf: cookies)
+                    } catch {
+                        debugLog("Failed to read browser cookies from \(path): \(error.localizedDescription)")
+                    }
+                }
+            } catch {
+                debugLog("Failed to prepare \(browser.displayName) cookie extraction: \(error.localizedDescription)")
+            }
+        }
+
+        guard !allCookies.isEmpty else {
+            throw BrowserCookieError.noBrowserFound
+        }
+
+        return allCookies
+    }
+
+    func getHistoryEntries(hostSuffix: String, pathPrefix: String, limit: Int = 100) throws -> [BrowserHistoryEntry] {
+        var allEntries: [BrowserHistoryEntry] = []
+        let normalizedHost = hostSuffix.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        for browser in SupportedBrowser.allCases {
+            for cookieDBPath in browser.cookieDBPaths {
+                let historyPath = URL(fileURLWithPath: cookieDBPath)
+                    .deletingLastPathComponent()
+                    .appendingPathComponent("History")
+                    .path
+
+                guard FileManager.default.fileExists(atPath: historyPath) else { continue }
+
+                do {
+                    let entries = try readHistoryEntries(
+                        from: historyPath,
+                        browser: browser,
+                        hostSuffix: normalizedHost,
+                        pathPrefix: pathPrefix,
+                        limit: limit
+                    )
+                    allEntries.append(contentsOf: entries)
+                } catch {
+                    debugLog("Failed to read browser history from \(historyPath): \(error.localizedDescription)")
+                }
+            }
+        }
+
+        guard !allEntries.isEmpty else {
+            throw BrowserCookieError.noBrowserFound
+        }
+
+        return allEntries.sorted { $0.lastVisitTime > $1.lastVisitTime }
     }
 
     // MARK: - Browser Detection & Cookie Extraction
@@ -231,6 +303,138 @@ class BrowserCookieService {
         )
     }
 
+    private func readBrowserCookies(
+        from dbPath: String,
+        aesKey: Data,
+        hostSuffix: String,
+        names: Set<String>
+    ) throws -> [BrowserCookie] {
+        let tempPath = NSTemporaryDirectory() + "browser_cookies_temp_\(UUID().uuidString).db"
+        try? FileManager.default.removeItem(atPath: tempPath)
+        try FileManager.default.copyItem(atPath: dbPath, toPath: tempPath)
+        defer { try? FileManager.default.removeItem(atPath: tempPath) }
+
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(tempPath, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
+            logger.error("Failed to open SQLite database at \(tempPath)")
+            throw BrowserCookieError.invalidCookieFormat
+        }
+        defer { sqlite3_close(db) }
+
+        let escapedHost = hostSuffix.replacingOccurrences(of: "'", with: "''")
+        let query = "SELECT name, encrypted_value, value, host_key FROM cookies WHERE host_key LIKE '%\(escapedHost)%' ORDER BY expires_utc DESC"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK else {
+            logger.error("Failed to prepare generic cookie SQLite statement")
+            throw BrowserCookieError.invalidCookieFormat
+        }
+        defer { sqlite3_finalize(statement) }
+
+        let dbURL = URL(fileURLWithPath: dbPath)
+        let profileName = dbURL.deletingLastPathComponent().lastPathComponent
+        let browser = SupportedBrowser.browser(forCookieDBPath: dbPath)
+        var cookies: [BrowserCookie] = []
+
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let namePtr = sqlite3_column_text(statement, 0),
+                  let domainPtr = sqlite3_column_text(statement, 3) else {
+                continue
+            }
+
+            let name = String(cString: namePtr)
+            guard names.isEmpty || names.contains(name) else { continue }
+
+            var value: String?
+            if let encryptedBlob = sqlite3_column_blob(statement, 1) {
+                let encryptedLength = Int(sqlite3_column_bytes(statement, 1))
+                if encryptedLength > 0 {
+                    let encryptedData = Data(bytes: encryptedBlob, count: encryptedLength)
+                    value = try? decryptCookie(encryptedData, aesKey: aesKey)
+                }
+            }
+
+            if value?.isEmpty ?? true,
+               let valuePtr = sqlite3_column_text(statement, 2) {
+                value = String(cString: valuePtr)
+            }
+
+            guard let value, !value.isEmpty else { continue }
+
+            cookies.append(BrowserCookie(
+                name: name,
+                value: value,
+                domain: String(cString: domainPtr),
+                browserName: browser?.displayName ?? "Browser",
+                profileName: profileName,
+                databasePath: dbPath
+            ))
+        }
+
+        return cookies
+    }
+
+    private func readHistoryEntries(
+        from dbPath: String,
+        browser: SupportedBrowser,
+        hostSuffix: String,
+        pathPrefix: String,
+        limit: Int
+    ) throws -> [BrowserHistoryEntry] {
+        let tempPath = NSTemporaryDirectory() + "browser_history_temp_\(UUID().uuidString).db"
+        try? FileManager.default.removeItem(atPath: tempPath)
+        try FileManager.default.copyItem(atPath: dbPath, toPath: tempPath)
+        defer { try? FileManager.default.removeItem(atPath: tempPath) }
+
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(tempPath, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
+            logger.error("Failed to open SQLite history database at \(tempPath)")
+            throw BrowserCookieError.invalidCookieFormat
+        }
+        defer { sqlite3_close(db) }
+
+        let escapedHost = hostSuffix.replacingOccurrences(of: "'", with: "''")
+        let escapedPrefix = pathPrefix.replacingOccurrences(of: "'", with: "''")
+        let cappedLimit = max(1, min(limit, 500))
+        let query = """
+            SELECT url, title, last_visit_time
+            FROM urls
+            WHERE url LIKE 'http%://%\(escapedHost)\(escapedPrefix)%'
+            ORDER BY last_visit_time DESC
+            LIMIT \(cappedLimit)
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK else {
+            logger.error("Failed to prepare browser history SQLite statement")
+            throw BrowserCookieError.invalidCookieFormat
+        }
+        defer { sqlite3_finalize(statement) }
+
+        let dbURL = URL(fileURLWithPath: dbPath)
+        let profileName = dbURL.deletingLastPathComponent().lastPathComponent
+        var entries: [BrowserHistoryEntry] = []
+
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let urlPtr = sqlite3_column_text(statement, 0),
+                  let url = URL(string: String(cString: urlPtr)) else {
+                continue
+            }
+
+            let title = sqlite3_column_text(statement, 1).map { String(cString: $0) }
+            let lastVisitTime = sqlite3_column_int64(statement, 2)
+
+            entries.append(BrowserHistoryEntry(
+                url: url,
+                title: title,
+                browserName: browser.displayName,
+                profileName: profileName,
+                databasePath: dbPath,
+                lastVisitTime: lastVisitTime
+            ))
+        }
+
+        return entries
+    }
+
     // MARK: - AES-CBC Decryption
 
     /// Chromium cookies: v10/v11 prefix, IV=16 spaces (0x20), skip first 32 garbage bytes
@@ -368,6 +572,12 @@ enum SupportedBrowser: CaseIterable {
             .map { "\(baseDir)/\($0)/Cookies" }
     }
 
+    static func browser(forCookieDBPath path: String) -> SupportedBrowser? {
+        allCases.first { browser in
+            browser.cookieDBPaths.contains(path)
+        }
+    }
+
     var keychainService: String {
         switch self {
         case .chrome: return "Chrome Safe Storage"
@@ -412,6 +622,40 @@ struct GitHubCookies {
             parts.append("logged_in=\(loggedIn)")
         }
         return parts.joined(separator: "; ")
+    }
+}
+
+struct BrowserCookie {
+    let name: String
+    let value: String
+    let domain: String
+    let browserName: String
+    let profileName: String
+    let databasePath: String
+
+    var profileKey: String {
+        "\(browserName)::\(profileName)::\(URL(fileURLWithPath: databasePath).deletingLastPathComponent().path)"
+    }
+
+    var displaySource: String {
+        "\(browserName) \(profileName)"
+    }
+}
+
+struct BrowserHistoryEntry {
+    let url: URL
+    let title: String?
+    let browserName: String
+    let profileName: String
+    let databasePath: String
+    let lastVisitTime: Int64
+
+    var profileKey: String {
+        "\(browserName)::\(profileName)::\(URL(fileURLWithPath: databasePath).deletingLastPathComponent().path)"
+    }
+
+    var displaySource: String {
+        "\(browserName) \(profileName)"
     }
 }
 

--- a/CopilotMonitor/CopilotMonitor/Services/ProviderManager.swift
+++ b/CopilotMonitor/CopilotMonitor/Services/ProviderManager.swift
@@ -38,6 +38,7 @@ actor ProviderManager {
             OpenRouterProvider(),
             AntigravityProvider(),
             OpenCodeZenProvider(),
+            OpenCodeGoProvider(),
             KimiProvider(),
             ChutesProvider(),
             SyntheticProvider(),

--- a/CopilotMonitor/CopilotMonitor/Services/TokenManager.swift
+++ b/CopilotMonitor/CopilotMonitor/Services/TokenManager.swift
@@ -218,6 +218,7 @@ struct OpenCodeAuth: Codable {
     let githubCopilot: OAuth?
     let openrouter: APIKey?
     let opencode: APIKey?
+    let openCodeGo: APIKey?
     let kimiForCoding: APIKey?
     let minimaxCodingPlan: APIKey?
     let zaiCodingPlan: APIKey?
@@ -227,6 +228,7 @@ struct OpenCodeAuth: Codable {
 
     enum CodingKeys: String, CodingKey {
         case anthropic, openai, openrouter, opencode, synthetic, chutes
+        case openCodeGo = "opencode-go"
         case githubCopilot = "github-copilot"
         case kimiForCoding = "kimi-for-coding"
         case minimaxCodingPlan = "minimax-coding-plan"
@@ -241,6 +243,7 @@ struct OpenCodeAuth: Codable {
         githubCopilot: OAuth?,
         openrouter: APIKey?,
         opencode: APIKey?,
+        openCodeGo: APIKey?,
         kimiForCoding: APIKey?,
         minimaxCodingPlan: APIKey?,
         zaiCodingPlan: APIKey?,
@@ -254,6 +257,7 @@ struct OpenCodeAuth: Codable {
         self.githubCopilot = githubCopilot
         self.openrouter = openrouter
         self.opencode = opencode
+        self.openCodeGo = openCodeGo
         self.kimiForCoding = kimiForCoding
         self.minimaxCodingPlan = minimaxCodingPlan
         self.zaiCodingPlan = zaiCodingPlan
@@ -273,6 +277,7 @@ struct OpenCodeAuth: Codable {
         githubCopilot = Self.decodeLossyIfPresent(OAuth.self, from: container, forKey: .githubCopilot)
         openrouter = Self.decodeLossyIfPresent(APIKey.self, from: container, forKey: .openrouter)
         opencode = Self.decodeLossyIfPresent(APIKey.self, from: container, forKey: .opencode)
+        openCodeGo = Self.decodeLossyIfPresent(APIKey.self, from: container, forKey: .openCodeGo)
         kimiForCoding = Self.decodeLossyIfPresent(APIKey.self, from: container, forKey: .kimiForCoding)
         minimaxCodingPlan = Self.decodeLossyIfPresent(APIKey.self, from: container, forKey: .minimaxCodingPlan)
         zaiCodingPlan = Self.decodeLossyIfPresent(APIKey.self, from: container, forKey: .zaiCodingPlan)
@@ -286,6 +291,7 @@ struct OpenCodeAuth: Codable {
            githubCopilot == nil,
            openrouter == nil,
            opencode == nil,
+           openCodeGo == nil,
            kimiForCoding == nil,
            minimaxCodingPlan == nil,
            zaiCodingPlan == nil,
@@ -322,6 +328,7 @@ struct OpenCodeAuth: Codable {
         try container.encodeIfPresent(githubCopilot, forKey: .githubCopilot)
         try container.encodeIfPresent(openrouter, forKey: .openrouter)
         try container.encodeIfPresent(opencode, forKey: .opencode)
+        try container.encodeIfPresent(openCodeGo, forKey: .openCodeGo)
         try container.encodeIfPresent(kimiForCoding, forKey: .kimiForCoding)
         try container.encodeIfPresent(minimaxCodingPlan, forKey: .minimaxCodingPlan)
         try container.encodeIfPresent(zaiCodingPlan, forKey: .zaiCodingPlan)
@@ -4152,6 +4159,11 @@ final class TokenManager: @unchecked Sendable {
         return auth.opencode?.key
     }
 
+    func getOpenCodeGoAPIKey() -> String? {
+        guard let auth = readOpenCodeAuth() else { return nil }
+        return auth.openCodeGo?.key
+    }
+
     func getKimiAPIKey() -> String? {
         guard let auth = readOpenCodeAuth() else { return nil }
         return auth.kimiForCoding?.key
@@ -4882,6 +4894,7 @@ final class TokenManager: @unchecked Sendable {
             debugLines.append(gitHubCopilotTokenStatusLine())
             debugLines.append("  [OpenRouter] \(auth.openrouter != nil ? "CONFIGURED" : "NOT CONFIGURED")")
             debugLines.append("  [OpenCode] \(auth.opencode != nil ? "CONFIGURED" : "NOT CONFIGURED")")
+            debugLines.append("  [OpenCode Go] \(auth.openCodeGo != nil ? "CONFIGURED" : "NOT CONFIGURED")")
             debugLines.append("  [Kimi] \(auth.kimiForCoding != nil ? "CONFIGURED" : "NOT CONFIGURED")")
             debugLines.append("  [MiniMax Coding Plan] \(auth.minimaxCodingPlan != nil ? "CONFIGURED" : "NOT CONFIGURED")")
             debugLines.append("  [Z.AI Coding Plan] \(auth.zaiCodingPlan != nil ? "CONFIGURED" : "NOT CONFIGURED")")
@@ -5182,6 +5195,14 @@ final class TokenManager: @unchecked Sendable {
                 debugLines.append("  - Key Preview: \(maskToken(opencode.key))")
             } else {
                 debugLines.append("[OpenCode] NOT CONFIGURED")
+            }
+
+            if let openCodeGo = auth.openCodeGo {
+                debugLines.append("[OpenCode Go] API Key Present")
+                debugLines.append("  - Key Length: \(openCodeGo.key.count) chars")
+                debugLines.append("  - Key Preview: \(maskToken(openCodeGo.key))")
+            } else {
+                debugLines.append("[OpenCode Go] NOT CONFIGURED")
             }
 
             // Kimi for Coding

--- a/CopilotMonitor/CopilotMonitor/Views/MultiProviderStatusBarIconView.swift
+++ b/CopilotMonitor/CopilotMonitor/Views/MultiProviderStatusBarIconView.swift
@@ -148,6 +148,8 @@ final class MultiProviderStatusBarIconView: NSView {
             iconName = "AntigravityIcon"
         case .openCodeZen:
             iconName = "OpencodeIcon"
+        case .openCodeGo:
+            iconName = "OpencodeIcon"
         case .kimi:
             iconName = "k.circle"
         case .minimaxCodingPlan:

--- a/CopilotMonitor/CopilotMonitor/Views/SwiftUI/ModernStatusBarIconView.swift
+++ b/CopilotMonitor/CopilotMonitor/Views/SwiftUI/ModernStatusBarIconView.swift
@@ -128,7 +128,7 @@ struct SwiftUIProviderAlertView: View {
         case .geminiCLI: return "sparkles"
         case .copilot: return "airplane"
         case .openRouter: return "dollarsign.circle"
-        case .openCode, .openCodeZen: return "chevron.left.forwardslash.chevron.right"
+        case .openCode, .openCodeZen, .openCodeGo: return "chevron.left.forwardslash.chevron.right"
         case .antigravity: return "arrow.up.circle"
         case .kimi: return "k.circle"
         case .zaiCodingPlan: return "globe"

--- a/CopilotMonitor/CopilotMonitorTests/OpenCodeGoProviderTests.swift
+++ b/CopilotMonitor/CopilotMonitorTests/OpenCodeGoProviderTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import OpenCode_Bar
+
+final class OpenCodeGoProviderTests: XCTestCase {
+    func testProviderIdentifier() {
+        let provider = OpenCodeGoProvider()
+        XCTAssertEqual(provider.identifier, .openCodeGo)
+    }
+
+    func testProviderType() {
+        let provider = OpenCodeGoProvider()
+        XCTAssertEqual(provider.type, .quotaBased)
+    }
+
+    func testDashboardUsageParserReadsEscapedUsageWindows() throws {
+        let html = #"""
+        <script>
+        self.__next_f.push([1,"{\"rollingUsage\":{\"usagePercent\":12.5,\"resetInSec\":3600},\"weeklyUsage\":{\"usagePercent\":\"25\",\"resetInSec\":\"7200\"},\"monthlyUsage\":{\"usagePercent\":50,\"resetInSec\":10800}}"])
+        </script>
+        """#
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+        let usage = try OpenCodeGoProvider.parseDashboardUsageHTML(html, now: now)
+
+        XCTAssertEqual(usage.rolling?.usagePercent ?? -1, 12.5, accuracy: 0.001)
+        XCTAssertEqual(usage.weekly?.usagePercent ?? -1, 25.0, accuracy: 0.001)
+        XCTAssertEqual(usage.monthly?.usagePercent ?? -1, 50.0, accuracy: 0.001)
+        XCTAssertEqual(usage.rolling?.resetInSeconds, 3_600)
+        XCTAssertEqual(usage.weekly?.resetDate, now.addingTimeInterval(7_200))
+        XCTAssertEqual(usage.monthly?.resetDate, now.addingTimeInterval(10_800))
+    }
+
+    func testDashboardUsageParserReadsSolidResourceReferences() throws {
+        let html = #"""
+        <script>
+        $R[24]($R[18],$R[30]={mine:!0,useBalance:!0,rollingUsage:$R[31]={status:"ok",resetInSec:18000,usagePercent:0},weeklyUsage:$R[32]={status:"ok",resetInSec:162822,usagePercent:31},monthlyUsage:$R[33]={status:"ok",resetInSec:1404782,usagePercent:21}});
+        </script>
+        """#
+
+        let usage = try OpenCodeGoProvider.parseDashboardUsageHTML(html)
+
+        XCTAssertEqual(usage.rolling?.usagePercent ?? -1, 0, accuracy: 0.001)
+        XCTAssertEqual(usage.weekly?.usagePercent ?? -1, 31, accuracy: 0.001)
+        XCTAssertEqual(usage.monthly?.usagePercent ?? -1, 21, accuracy: 0.001)
+        XCTAssertEqual(usage.rolling?.resetInSeconds, 18_000)
+    }
+
+    func testWorkspaceIDExtractionKeepsRecentOrderAndDeduplicates() {
+        let urls = [
+            "https://opencode.ai/workspace/wrk_01ABCDEF0123456789ABCDEFG/go",
+            "https://opencode.ai/workspace/wrk_01SECOND0123456789ABCDEF/usage",
+            "https://opencode.ai/workspace/wrk_01ABCDEF0123456789ABCDEFG/keys",
+            "https://opencode.ai/go"
+        ]
+
+        XCTAssertEqual(
+            OpenCodeGoProvider.extractWorkspaceIDs(from: urls),
+            [
+                "wrk_01ABCDEF0123456789ABCDEFG",
+                "wrk_01SECOND0123456789ABCDEF"
+            ]
+        )
+    }
+
+    func testOpenCodeGoAPIKeyDecodes() throws {
+        let json = """
+        {
+            "opencode-go": {
+                "type": "api",
+                "key": "opencode-go-test-key"
+            }
+        }
+        """
+
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let auth = try JSONDecoder().decode(OpenCodeAuth.self, from: data)
+
+        XCTAssertEqual(auth.openCodeGo?.key, "opencode-go-test-key")
+    }
+}

--- a/CopilotMonitor/CopilotMonitorTests/OpenCodeGoProviderTests.swift
+++ b/CopilotMonitor/CopilotMonitorTests/OpenCodeGoProviderTests.swift
@@ -45,6 +45,21 @@ final class OpenCodeGoProviderTests: XCTestCase {
         XCTAssertEqual(usage.rolling?.resetInSeconds, 18_000)
     }
 
+    func testDashboardUsageParserKeepsPartialUsageWindows() throws {
+        let html = #"""
+        <script>
+        self.__next_f.push([1,"{\"rollingUsage\":{\"usagePercent\":64,\"resetInSec\":900}}"])
+        </script>
+        """#
+
+        let usage = try OpenCodeGoProvider.parseDashboardUsageHTML(html)
+
+        XCTAssertEqual(usage.rolling?.usagePercent ?? -1, 64, accuracy: 0.001)
+        XCTAssertNil(usage.weekly)
+        XCTAssertNil(usage.monthly)
+        XCTAssertEqual(usage.missingWindowNames, ["weeklyUsage", "monthlyUsage"])
+    }
+
     func testWorkspaceIDExtractionKeepsRecentOrderAndDeduplicates() {
         let urls = [
             "https://opencode.ai/workspace/wrk_01ABCDEF0123456789ABCDEFG/go",

--- a/CopilotMonitor/CopilotMonitorTests/ProviderUsageTests.swift
+++ b/CopilotMonitor/CopilotMonitorTests/ProviderUsageTests.swift
@@ -202,6 +202,35 @@ final class ProviderUsageTests: XCTestCase {
         XCTAssertEqual(UsagePercentDisplayFormatter.wholePercent(from: 0.4), 1)
     }
 
+    func testStatusBarQuotaVisibilityHidesExhaustedCandidatesWhenQuotaRemains() {
+        let candidates = [
+            (provider: ProviderIdentifier.claude, usedPercent: 100.0),
+            (provider: ProviderIdentifier.codex, usedPercent: 95.0),
+            (provider: ProviderIdentifier.kimi, usedPercent: 120.0)
+        ]
+
+        let visible = StatusBarQuotaVisibilityPolicy.visibleCandidates(
+            from: candidates,
+            usedPercent: { $0.usedPercent }
+        )
+
+        XCTAssertEqual(visible.map(\.provider), [.codex])
+    }
+
+    func testStatusBarQuotaVisibilityAllowsExhaustedCandidatesWhenAllQuotaIsExhausted() {
+        let candidates = [
+            (provider: ProviderIdentifier.claude, usedPercent: 100.0),
+            (provider: ProviderIdentifier.codex, usedPercent: 120.0)
+        ]
+
+        let visible = StatusBarQuotaVisibilityPolicy.visibleCandidates(
+            from: candidates,
+            usedPercent: { $0.usedPercent }
+        )
+
+        XCTAssertEqual(visible.map(\.provider), [.claude, .codex])
+    }
+
     func testTableFormatterShowsOnePercentForMiniMaxSubOnePercentUsage() {
         let usage = ProviderUsage.quotaBased(remaining: 99, entitlement: 100, overagePermitted: false)
         let details = DetailedUsage(fiveHourUsage: 0.4, sevenDayUsage: 0.2)

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ OpenRouter            Pay-as-you-go    -           $37.42 spent
 - OpenCode Go is resolved from the OpenCode auth entry `opencode-go` in `auth.json`.
 - OpenCode Bar validates the API key against `https://opencode.ai/zen/go/v1/models`.
 - Usage windows come from the OpenCode dashboard and require `OPENCODE_GO_WORKSPACE_ID` plus `OPENCODE_GO_AUTH_COOKIE`, or `~/.config/opencode-bar/opencode-go.json`.
+- The monthly dashboard window is a usage cap signal; the app's subscription preset for the Go plan remains `$10.00`.
 
 #### JSON Output Example
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Download the latest `.dmg` file from the [**Releases**](https://github.com/opggi
 | **Nano-GPT** | Quota-based | Weekly input tokens quota, USD/NANO balance |
 | **Kimi for Coding (Kimi K2.5)** | Quota-based | Usage limits, membership level, reset time |
 | **MiniMax Coding Plan** | Quota-based | 5h/weekly quotas, Anthropic-style dual-window submenu, OpenCode auth |
+| **OpenCode Go** | Quota-based | 5h/weekly/monthly usage windows, model API validation, OpenCode auth |
 | **Z.AI Coding Plan** | Quota-based | Token/MCP quotas, model usage, tool usage (24h) |
 | **Brave Search** | Quota-based | Monthly search quota, reset schedule |
 | **Tavily** | Quota-based | Monthly search quota, plan usage |
@@ -176,6 +177,7 @@ opencodebar list
 opencodebar provider claude
 opencodebar provider gemini_cli
 opencodebar provider minimax_coding_plan
+opencodebar provider opencode_go
 
 # Output as JSON (for scripting)
 opencodebar status --json
@@ -198,6 +200,7 @@ Gemini CLI (user1@gmail.com) Quota-based      0%          100% remaining
 Gemini CLI (user2@company.com) Quota-based    15%         85% remaining
 Kimi for Coding       Quota-based      26%         74/100 remaining
 MiniMax Coding Plan   Quota-based      0%,0%      100/100 remaining
+OpenCode Go           Quota-based      12%,25%,50% 50/100 remaining
 OpenCode Zen          Pay-as-you-go    -           $12.50 spent
 OpenRouter            Pay-as-you-go    -           $37.42 spent
 ```
@@ -207,6 +210,12 @@ OpenRouter            Pay-as-you-go    -           $37.42 spent
 - MiniMax Coding Plan is resolved from the OpenCode auth entry `minimax-coding-plan` in `auth.json`.
 - OpenCode Bar uses the Coding Plan remains endpoint and converts it into used percentages for the menu bar app and CLI.
 - MiniMax response fields `current_interval_usage_count` and `current_weekly_usage_count` behave as remaining counts despite their names, so OpenCode Bar calculates used percent as `total - remaining`.
+
+#### OpenCode Go Notes
+
+- OpenCode Go is resolved from the OpenCode auth entry `opencode-go` in `auth.json`.
+- OpenCode Bar validates the API key against `https://opencode.ai/zen/go/v1/models`.
+- Usage windows come from the OpenCode dashboard and require `OPENCODE_GO_WORKSPACE_ID` plus `OPENCODE_GO_AUTH_COOKIE`, or `~/.config/opencode-bar/opencode-go.json`.
 
 #### JSON Output Example
 
@@ -367,6 +376,8 @@ Quit (⌘Q)
 5. **Graceful Degradation**: Shows available providers even if some fail
 
 MiniMax Coding Plan uses `https://api.minimax.io/v1/api/openplatform/coding_plan/remains` and is displayed with explicit 5h used and weekly used windows in the provider submenu.
+
+OpenCode Go reads the API key from the OpenCode auth entry `opencode-go`. Current usage is exposed by the OpenCode dashboard, so live usage also needs `OPENCODE_GO_WORKSPACE_ID` and `OPENCODE_GO_AUTH_COOKIE`, or a local `~/.config/opencode-bar/opencode-go.json` file with `workspaceId` and `authCookie`.
 
 ### Privacy & Security
 

--- a/docs/AI_USAGE_API_REFERENCE.md
+++ b/docs/AI_USAGE_API_REFERENCE.md
@@ -8,7 +8,7 @@
 |----------|-----------|
 | Claude | `~/.config/opencode/opencode-anthropic-auth/accounts.json`, `~/.local/share/opencode/auth.json`, `~/.config/claude-code/auth.json`, macOS Keychain (`Claude Code-credentials`, `Claude Code`) |
 | Codex / ChatGPT | `~/.local/share/opencode/auth.json`, `~/.opencode/auth/openai.json`, `~/.opencode/openai-codex-accounts.json`, `~/.opencode/projects/*/openai-codex-accounts.json`, `~/.codex/auth.json`, `~/.codex-lb/` |
-| Copilot, Nano-GPT, MiniMax | `~/.local/share/opencode/auth.json` |
+| Copilot, Nano-GPT, MiniMax, OpenCode Go | `~/.local/share/opencode/auth.json` |
 | Antigravity (Gemini) | `~/.config/opencode/antigravity-accounts.json` |
 | Antigravity (Local cache) | `~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb` |
 
@@ -271,7 +271,47 @@ The bundled [`scripts/query-minimax.sh`](/Users/kargnas/projects/opencode-bar/sc
 
 ---
 
-## 6. Antigravity (Dual Quota System)
+## 6. OpenCode Go
+
+**Model endpoint:** `GET https://opencode.ai/zen/go/v1/models`
+
+OpenCode Go credentials are stored in the OpenCode auth entry `opencode-go`.
+
+```bash
+API_KEY=$(jq -r '."opencode-go".key' ~/.local/share/opencode/auth.json)
+
+curl -s "https://opencode.ai/zen/go/v1/models" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Accept: application/json"
+```
+
+OpenCode Go usage is currently exposed through the OpenCode dashboard. OpenCode Bar reads the dashboard page when both a workspace ID and browser auth cookie are configured:
+
+```json
+{
+  "workspaceId": "your-workspace-id",
+  "authCookie": "your-auth-cookie"
+}
+```
+
+Supported config paths:
+
+- `~/.config/opencode-bar/opencode-go.json`
+- `~/.config/opencode-quota/opencode-go.json`
+
+Environment overrides:
+
+- `OPENCODE_GO_WORKSPACE_ID`
+- `OPENCODE_GO_AUTH_COOKIE`
+- `OPENCODE_GO_CONFIG_FILE`
+
+OpenCode Go is displayed with explicit 5-hour, weekly, and monthly used percentages. The official limits are value-based: 5h `$12`, weekly `$30`, monthly `$60`; the subscription preset is `Go ($10/m)`.
+
+The bundled [`scripts/query-opencode-go.sh`](/Users/kargnas/projects/opencode-bar/scripts/query-opencode-go.sh) validates the API key and prints the dashboard usage windows when dashboard config is available.
+
+---
+
+## 7. Antigravity (Dual Quota System)
 
 Antigravity has **two independent quota systems**:
 
@@ -499,6 +539,7 @@ Test scripts are located in the `scripts/` folder:
 | `query-codex.sh` | Codex (OpenAI) |
 | `query-copilot.sh` | GitHub Copilot |
 | `query-minimax.sh` | MiniMax Coding Plan |
+| `query-opencode-go.sh` | OpenCode Go |
 | `query-gemini-cli.sh` | Antigravity - Gemini CLI quota |
 | `query-gemini-oauth-creds.sh` | Gemini CLI oauth_creds identity/token inspection |
 | `query-antigravity-local.sh` | Antigravity - Local quota (cache reverse parsing alias) |

--- a/scripts/query-all.sh
+++ b/scripts/query-all.sh
@@ -9,7 +9,7 @@ echo "    $(date '+%Y-%m-%d %H:%M:%S')"
 echo "========================================"
 echo ""
 
-for script in query-claude.sh query-codex.sh query-copilot.sh query-gemini-cli.sh query-antigravity-local.sh query-openrouter.sh query-synthetic.sh query-nano-gpt.sh query-brave-search.sh query-tavily-search.sh query-minimax.sh; do
+for script in query-claude.sh query-codex.sh query-copilot.sh query-gemini-cli.sh query-antigravity-local.sh query-openrouter.sh query-synthetic.sh query-nano-gpt.sh query-brave-search.sh query-tavily-search.sh query-minimax.sh query-opencode-go.sh; do
     if [[ -x "$SCRIPT_DIR/$script" ]]; then
         "$SCRIPT_DIR/$script" 2>/dev/null || echo "$script: Failed"
         echo ""

--- a/scripts/query-opencode-go.sh
+++ b/scripts/query-opencode-go.sh
@@ -1,0 +1,719 @@
+#!/usr/bin/env bash
+# Query OpenCode Go API-key status and dashboard usage.
+#
+# OpenCode stores the Go model API key in the OpenCode data auth file under:
+#   ~/.local/share/opencode/auth.json -> ["opencode-go"].key
+#
+# The key validates access to the OpenCode Go model API. Usage windows are
+# exposed by the web dashboard. This script first uses explicit dashboard
+# config, then falls back to Chromium browser auth cookies and workspace
+# history from Chrome, Brave, Arc, or Edge.
+
+set -euo pipefail
+
+PROVIDER_ID="opencode-go"
+MODELS_URL="https://opencode.ai/zen/go/v1/models"
+DASHBOARD_BASE_URL="https://opencode.ai/workspace"
+
+JSON_OUTPUT=false
+MODELS_ONLY=false
+AUTH_FILE_OVERRIDE="${OPENCODE_GO_AUTH_FILE:-${OPENCODE_AUTH_FILE:-}}"
+CONFIG_FILE_OVERRIDE="${OPENCODE_GO_CONFIG_FILE:-}"
+API_KEY="${OPENCODE_GO_API_KEY:-${OPENCODE_API_KEY:-}}"
+API_KEY_SOURCE=""
+WORKSPACE_ID="${OPENCODE_GO_WORKSPACE_ID:-}"
+AUTH_COOKIE="${OPENCODE_GO_AUTH_COOKIE:-}"
+USAGE_CONFIG_SOURCE=""
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/query-opencode-go.sh [options]
+
+Options:
+  --json                    Print machine-readable JSON
+  --models-only             Validate the OpenCode Go API key only
+  --auth-file PATH          Read OpenCode auth from PATH
+  --config-file PATH        Read dashboard usage config from PATH
+  --workspace-id ID         OpenCode workspace ID for dashboard usage scraping
+  --auth-cookie COOKIE      Browser auth cookie value for dashboard usage scraping
+  -h, --help                Show this help
+
+Environment:
+  OPENCODE_GO_API_KEY       OpenCode Go API key override
+  OPENCODE_API_KEY          OpenCode API key override used by the Go provider
+  OPENCODE_GO_AUTH_FILE     OpenCode auth.json path override
+  OPENCODE_AUTH_FILE        OpenCode auth.json path override
+  OPENCODE_GO_CONFIG_FILE   Dashboard config JSON path override
+  OPENCODE_GO_WORKSPACE_ID  Workspace ID for https://opencode.ai/workspace/<id>/go
+  OPENCODE_GO_AUTH_COOKIE   Browser auth cookie value for the OpenCode dashboard
+
+Config file:
+  ~/.config/opencode-bar/opencode-go.json or ~/.config/opencode-quota/opencode-go.json
+  with fields: {"workspaceId":"...","authCookie":"..."}
+
+Fallback:
+  If dashboard config is not set, the script tries to read the opencode.ai
+  auth cookie and recent /workspace/<id>/go visits from Chromium browser
+  profiles on this Mac.
+EOF
+}
+
+fail() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || fail "Required command not found: $1"
+}
+
+mask_secret() {
+    local value="$1"
+    local length=${#value}
+
+    if (( length <= 8 )); then
+        printf '***'
+        return
+    fi
+
+    local prefix="${value:0:6}"
+    local suffix_start=$((length - 4))
+    local suffix="${value:suffix_start:4}"
+    printf '%s...%s' "$prefix" "$suffix"
+}
+
+parse_args() {
+    while (($#)); do
+        case "$1" in
+            --json)
+                JSON_OUTPUT=true
+                shift
+                ;;
+            --models-only)
+                MODELS_ONLY=true
+                shift
+                ;;
+            --auth-file)
+                [[ $# -ge 2 ]] || fail "--auth-file requires a path"
+                AUTH_FILE_OVERRIDE="$2"
+                shift 2
+                ;;
+            --config-file)
+                [[ $# -ge 2 ]] || fail "--config-file requires a path"
+                CONFIG_FILE_OVERRIDE="$2"
+                shift 2
+                ;;
+            --workspace-id)
+                [[ $# -ge 2 ]] || fail "--workspace-id requires a value"
+                WORKSPACE_ID="$2"
+                shift 2
+                ;;
+            --auth-cookie)
+                [[ $# -ge 2 ]] || fail "--auth-cookie requires a value"
+                AUTH_COOKIE="$2"
+                shift 2
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                fail "Unknown option: $1"
+                ;;
+        esac
+    done
+}
+
+auth_file_candidates() {
+    if [[ -n "$AUTH_FILE_OVERRIDE" ]]; then
+        printf '%s\n' "$AUTH_FILE_OVERRIDE"
+    fi
+
+    if [[ -n "${XDG_DATA_HOME:-}" ]]; then
+        printf '%s\n' "$XDG_DATA_HOME/opencode/auth.json"
+    fi
+
+    printf '%s\n' "$HOME/.local/share/opencode/auth.json"
+    printf '%s\n' "$HOME/Library/Application Support/opencode/auth.json"
+}
+
+find_auth_file() {
+    local candidate
+    while IFS= read -r candidate; do
+        [[ -n "$candidate" ]] || continue
+        if [[ -f "$candidate" ]]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done < <(auth_file_candidates)
+
+    return 1
+}
+
+load_api_key() {
+    if [[ -n "$API_KEY" ]]; then
+        API_KEY_SOURCE="environment"
+        return
+    fi
+
+    local auth_file
+    auth_file="$(find_auth_file)" || {
+        fail "OpenCode auth file not found. Expected ~/.local/share/opencode/auth.json or set OPENCODE_GO_API_KEY."
+    }
+
+    API_KEY="$(jq -r --arg provider "$PROVIDER_ID" '.[$provider].key // empty' "$auth_file")"
+    [[ -n "$API_KEY" ]] || {
+        fail "No OpenCode Go API key found at $auth_file under key \"$PROVIDER_ID\"."
+    }
+
+    API_KEY_SOURCE="$auth_file"
+}
+
+dashboard_config_candidates() {
+    if [[ -n "$CONFIG_FILE_OVERRIDE" ]]; then
+        printf '%s\n' "$CONFIG_FILE_OVERRIDE"
+    fi
+
+    if [[ -n "${XDG_CONFIG_HOME:-}" ]]; then
+        printf '%s\n' "$XDG_CONFIG_HOME/opencode-bar/opencode-go.json"
+        printf '%s\n' "$XDG_CONFIG_HOME/opencode-quota/opencode-go.json"
+    fi
+
+    printf '%s\n' "$HOME/.config/opencode-bar/opencode-go.json"
+    printf '%s\n' "$HOME/.config/opencode-quota/opencode-go.json"
+    printf '%s\n' "$HOME/Library/Application Support/opencode-bar/opencode-go.json"
+    printf '%s\n' "$HOME/Library/Application Support/opencode-quota/opencode-go.json"
+}
+
+load_dashboard_config() {
+    if [[ -n "$WORKSPACE_ID" && -n "$AUTH_COOKIE" ]]; then
+        USAGE_CONFIG_SOURCE="environment"
+        return
+    fi
+
+    local candidate
+    while IFS= read -r candidate; do
+        [[ -n "$candidate" ]] || continue
+        [[ -f "$candidate" ]] || continue
+
+        local workspace_id auth_cookie
+        workspace_id="$(jq -r '.workspaceId // .workspaceID // .workspace_id // empty' "$candidate" 2>/dev/null || true)"
+        auth_cookie="$(jq -r '.authCookie // .auth_cookie // .cookie // empty' "$candidate" 2>/dev/null || true)"
+
+        if [[ -n "$workspace_id" && -n "$auth_cookie" ]]; then
+            [[ -n "$WORKSPACE_ID" ]] || WORKSPACE_ID="$workspace_id"
+            [[ -n "$AUTH_COOKIE" ]] || AUTH_COOKIE="$auth_cookie"
+            USAGE_CONFIG_SOURCE="$candidate"
+            return
+        fi
+    done < <(dashboard_config_candidates)
+}
+
+validate_models_api() {
+    local body_file
+    body_file="$(mktemp)"
+
+    local status
+    status="$(
+        curl -sS -L -o "$body_file" -w '%{http_code}' "$MODELS_URL" \
+            -H "Authorization: Bearer $API_KEY" \
+            -H "Accept: application/json" || true
+    )"
+
+    if [[ ! "$status" =~ ^2 ]]; then
+        local message
+        message="$(jq -r '.error.message // .message // .error // empty' "$body_file" 2>/dev/null || true)"
+        rm -f "$body_file"
+        [[ -n "$message" ]] || message="HTTP $status from $MODELS_URL"
+        fail "OpenCode Go API key validation failed: $message"
+    fi
+
+    local model_count
+    model_count="$(jq -r '(.data // .models // []) | length' "$body_file")"
+    rm -f "$body_file"
+    printf '%s\n' "$model_count"
+}
+
+fetch_dashboard_usage() {
+    [[ -n "$WORKSPACE_ID" ]] || return 3
+    [[ -n "$AUTH_COOKIE" ]] || return 3
+
+    local dashboard_url="$DASHBOARD_BASE_URL/$WORKSPACE_ID/go"
+    local cookie_header="auth=$AUTH_COOKIE"
+    if [[ "$AUTH_COOKIE" == *"auth="* ]]; then
+        cookie_header="$AUTH_COOKIE"
+    fi
+
+    local html_file
+    html_file="$(mktemp)"
+
+    local status
+    status="$(
+        curl -sS -L -o "$html_file" -w '%{http_code}' "$dashboard_url" \
+            -H "Accept: text/html,application/xhtml+xml" \
+            -H "Cookie: $cookie_header" \
+            -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36" || true
+    )"
+
+    if [[ ! "$status" =~ ^2 ]]; then
+        rm -f "$html_file"
+        return 4
+    fi
+
+    python3 - "$html_file" <<'PY'
+import datetime as dt
+import html
+import json
+import re
+import sys
+
+path = sys.argv[1]
+raw = open(path, "r", encoding="utf-8", errors="ignore").read()
+text = html.unescape(raw).replace('\\"', '"')
+
+fields = {
+    "rolling": ("rollingUsage", "5h"),
+    "weekly": ("weeklyUsage", "Weekly"),
+    "monthly": ("monthlyUsage", "Monthly"),
+}
+
+number = r'"?(-?\d+(?:\.\d+)?)"?'
+now = dt.datetime.now(dt.timezone.utc)
+windows = {}
+
+def duration(seconds):
+    seconds = max(0, int(seconds))
+    days, rem = divmod(seconds, 86400)
+    hours, rem = divmod(rem, 3600)
+    minutes = rem // 60
+    if days:
+        return f"{days}d {hours}h"
+    if hours:
+        return f"{hours}h {minutes}m"
+    return f"{minutes}m"
+
+for key, (field, label) in fields.items():
+    object_match = re.search(rf'["\']?{re.escape(field)}["\']?\s*:\s*(?:\$R\[\d+\]\s*=\s*)?\{{(?P<body>[^{{}}]*)\}}', text, re.DOTALL)
+    if not object_match:
+        continue
+
+    body = object_match.group("body")
+    usage_match = re.search(rf'["\']?usagePercent["\']?\s*:\s*{number}', body)
+    reset_match = re.search(rf'["\']?resetInSec["\']?\s*:\s*{number}', body)
+    if not usage_match or not reset_match:
+        continue
+
+    usage_percent = float(usage_match.group(1))
+    reset_seconds = int(float(reset_match.group(1)))
+    reset_at = now + dt.timedelta(seconds=reset_seconds)
+    windows[key] = {
+        "field": field,
+        "label": label,
+        "usage_percent": usage_percent,
+        "percent_remaining": max(0.0, 100.0 - usage_percent),
+        "reset_in_seconds": reset_seconds,
+        "reset_in": duration(reset_seconds),
+        "resets_at": reset_at.isoformat().replace("+00:00", "Z"),
+    }
+
+if not windows:
+    print(json.dumps({"error": "No OpenCode Go usage windows found in dashboard HTML"}))
+    sys.exit(2)
+
+print(json.dumps({"windows": windows}, sort_keys=True))
+PY
+
+    local parse_status=$?
+    rm -f "$html_file"
+    return "$parse_status"
+}
+
+discover_browser_dashboard_candidates() {
+    python3 <<'PY'
+import json
+import os
+import re
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from hashlib import pbkdf2_hmac
+from pathlib import Path
+
+try:
+    from Crypto.Cipher import AES
+    CRYPTO_BACKEND = "pycryptodome"
+except ImportError:
+    try:
+        from cryptography.hazmat.backends import default_backend
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+        CRYPTO_BACKEND = "cryptography"
+    except ImportError:
+        CRYPTO_BACKEND = None
+
+
+@dataclass
+class Browser:
+    name: str
+    base: Path
+    keychain_service: str
+    keychain_account: str
+
+
+BROWSERS = [
+    Browser("Chrome", Path("~/Library/Application Support/Google/Chrome").expanduser(), "Chrome Safe Storage", "Chrome"),
+    Browser("Brave", Path("~/Library/Application Support/BraveSoftware/Brave-Browser").expanduser(), "Brave Safe Storage", "Brave"),
+    Browser("Arc", Path("~/Library/Application Support/Arc/User Data").expanduser(), "Arc Safe Storage", "Arc"),
+    Browser("Edge", Path("~/Library/Application Support/Microsoft Edge").expanduser(), "Microsoft Edge Safe Storage", "Microsoft Edge"),
+]
+
+
+def fail_quietly():
+    sys.exit(0)
+
+
+if CRYPTO_BACKEND is None:
+    fail_quietly()
+
+
+def profiles(browser):
+    if not browser.base.exists():
+        return []
+    result = []
+    for child in browser.base.iterdir():
+        if child.name == "Default" or child.name.startswith("Profile "):
+            if (child / "Cookies").exists() and (child / "History").exists():
+                result.append(child)
+    return result
+
+
+def key_for(browser):
+    password = subprocess.check_output(
+        [
+            "security",
+            "find-generic-password",
+            "-s",
+            browser.keychain_service,
+            "-a",
+            browser.keychain_account,
+            "-w",
+        ],
+        stderr=subprocess.DEVNULL,
+    ).rstrip(b"\n")
+    return pbkdf2_hmac("sha1", password, b"saltysalt", 1003, 16)
+
+
+def decrypt_cookie(encrypted_value, key):
+    if not encrypted_value:
+        return ""
+    if not encrypted_value.startswith((b"v10", b"v11")):
+        try:
+            return encrypted_value.decode("utf-8")
+        except UnicodeDecodeError:
+            return ""
+
+    encrypted_value = encrypted_value[3:]
+    iv = b" " * 16
+    if CRYPTO_BACKEND == "pycryptodome":
+        decrypted = AES.new(key, AES.MODE_CBC, iv).decrypt(encrypted_value)
+    else:
+        decryptor = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend()).decryptor()
+        decrypted = decryptor.update(encrypted_value) + decryptor.finalize()
+
+    padding = decrypted[-1]
+    if 1 <= padding <= 16 and decrypted.endswith(bytes([padding]) * padding):
+        decrypted = decrypted[:-padding]
+
+    if len(decrypted) > 32 and decrypted[32:].startswith(b"Fe26."):
+        decrypted = decrypted[32:]
+    elif len(decrypted) > 32:
+        candidate = decrypted[32:]
+        if all((byte >= 32 or byte in (9, 10, 13)) for byte in candidate[:16]):
+            decrypted = candidate
+
+    try:
+        return decrypted.decode("utf-8")
+    except UnicodeDecodeError:
+        return ""
+
+
+def copy_db(path):
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".db")
+    tmp.close()
+    shutil.copy2(path, tmp.name)
+    return tmp.name
+
+
+def auth_cookie(profile, key):
+    tmp_path = copy_db(profile / "Cookies")
+    try:
+        conn = sqlite3.connect(tmp_path)
+        rows = conn.execute(
+            """
+            SELECT encrypted_value, value
+            FROM cookies
+            WHERE host_key LIKE '%opencode.ai' AND name = 'auth'
+            ORDER BY expires_utc DESC
+            LIMIT 1
+            """
+        ).fetchall()
+        conn.close()
+    finally:
+        os.unlink(tmp_path)
+
+    if not rows:
+        return ""
+
+    encrypted_value, plain_value = rows[0]
+    if plain_value:
+        return plain_value
+    return decrypt_cookie(encrypted_value, key)
+
+
+def workspace_history(profile):
+    tmp_path = copy_db(profile / "History")
+    try:
+        conn = sqlite3.connect(tmp_path)
+        rows = conn.execute(
+            """
+            SELECT url, last_visit_time
+            FROM urls
+            WHERE url LIKE 'https://opencode.ai/workspace/%'
+            ORDER BY last_visit_time DESC
+            LIMIT 100
+            """
+        ).fetchall()
+        conn.close()
+    finally:
+        os.unlink(tmp_path)
+
+    seen = set()
+    result = []
+    for url, last_visit_time in rows:
+        match = re.search(r"/workspace/(wrk_[A-Z0-9]+)", url)
+        if not match:
+            continue
+        workspace_id = match.group(1)
+        if workspace_id in seen:
+            continue
+        seen.add(workspace_id)
+        result.append((workspace_id, last_visit_time))
+    return result
+
+
+all_candidates = []
+for browser in BROWSERS:
+    try:
+        key = key_for(browser)
+    except Exception:
+        continue
+
+    for profile in profiles(browser):
+        try:
+            cookie = auth_cookie(profile, key)
+            workspaces = workspace_history(profile)
+        except Exception:
+            continue
+
+        if not cookie or not workspaces:
+            continue
+
+        for workspace_id, last_visit_time in workspaces:
+            all_candidates.append(
+                {
+                    "workspaceId": workspace_id,
+                    "authCookie": cookie,
+                    "source": f"Browser Cookies ({browser.name} {profile.name})",
+                    "lastVisitTime": last_visit_time,
+                }
+            )
+
+seen = set()
+for candidate in sorted(all_candidates, key=lambda item: item["lastVisitTime"], reverse=True):
+    key = (candidate["workspaceId"], candidate["authCookie"])
+    if key in seen:
+        continue
+    seen.add(key)
+    print(json.dumps(candidate, separators=(",", ":")))
+PY
+}
+
+fetch_browser_dashboard_usage() {
+    local candidates_file
+    candidates_file="$(mktemp)"
+    discover_browser_dashboard_candidates > "$candidates_file"
+
+    if [[ ! -s "$candidates_file" ]]; then
+        rm -f "$candidates_file"
+        return 3
+    fi
+
+    local line
+    local found_usage_json=""
+    while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+
+        WORKSPACE_ID="$(jq -r '.workspaceId // empty' <<<"$line")"
+        AUTH_COOKIE="$(jq -r '.authCookie // empty' <<<"$line")"
+        USAGE_CONFIG_SOURCE="$(jq -r '.source // "Browser Cookies"' <<<"$line")"
+
+        [[ -n "$WORKSPACE_ID" && -n "$AUTH_COOKIE" ]] || continue
+
+        local usage_json
+        if usage_json="$(fetch_dashboard_usage)"; then
+            found_usage_json="$(
+                jq --arg source "$USAGE_CONFIG_SOURCE" '. + {_usage_source: $source}' <<<"$usage_json"
+            )"
+            break
+        fi
+    done < "$candidates_file"
+
+    rm -f "$candidates_file"
+
+    if [[ -n "$found_usage_json" ]]; then
+        printf '%s\n' "$found_usage_json"
+        return 0
+    fi
+
+    return 4
+}
+
+print_text_result() {
+    local model_count="$1"
+    local usage_json="${2:-}"
+    local usage_error="${3:-}"
+
+    echo "=== OpenCode Go Usage ==="
+    echo ""
+    echo "Auth source: $API_KEY_SOURCE"
+    echo "API key: $(mask_secret "$API_KEY")"
+    echo "Model API: OK ($model_count models available)"
+
+    if [[ "$MODELS_ONLY" == true ]]; then
+        return
+    fi
+
+    echo ""
+    if [[ -z "$usage_json" ]]; then
+        echo "Usage: not available"
+        if [[ -n "$usage_error" ]]; then
+            echo "Reason: $usage_error"
+        else
+            echo "Reason: dashboard usage requires a browser login/history match, OPENCODE_GO_WORKSPACE_ID and OPENCODE_GO_AUTH_COOKIE, or ~/.config/opencode-bar/opencode-go.json."
+        fi
+        echo "Note: no public API-key-only usage endpoint was found for OpenCode Go."
+        return
+    fi
+
+    if [[ -n "$USAGE_CONFIG_SOURCE" ]]; then
+        echo "Usage source: $USAGE_CONFIG_SOURCE"
+    fi
+    echo "$usage_json" | jq -r '
+        def pct: ((. * 100 | round) / 100 | tostring);
+        .windows
+        | to_entries[]
+        | "\(.value.label): \(.value.usage_percent | pct)% used, \(.value.percent_remaining | pct)% left, resets in \(.value.reset_in) (\(.value.resets_at))"
+    '
+}
+
+print_json_result() {
+    local model_count="$1"
+    local usage_json="${2:-null}"
+    local usage_error="${3:-}"
+
+    jq -n \
+        --arg provider "$PROVIDER_ID" \
+        --arg auth_source "$API_KEY_SOURCE" \
+        --arg key_preview "$(mask_secret "$API_KEY")" \
+        --arg models_url "$MODELS_URL" \
+        --arg usage_source "$USAGE_CONFIG_SOURCE" \
+        --argjson model_count "$model_count" \
+        --argjson usage "$usage_json" \
+        --arg usage_error "$usage_error" \
+        '{
+            provider: $provider,
+            auth: {
+                source: $auth_source,
+                key_preview: $key_preview
+            },
+            models: {
+                endpoint: $models_url,
+                status: "ok",
+                count: $model_count
+            },
+            usage: $usage,
+            usage_source: (if $usage_source == "" then null else $usage_source end),
+            usage_error: (if $usage_error == "" then null else $usage_error end)
+        }'
+}
+
+main() {
+    parse_args "$@"
+    require_command curl
+    require_command jq
+    require_command python3
+
+    load_api_key
+    load_dashboard_config
+
+    local model_count
+    model_count="$(validate_models_api)"
+
+    if [[ "$MODELS_ONLY" == true ]]; then
+        if [[ "$JSON_OUTPUT" == true ]]; then
+            print_json_result "$model_count"
+        else
+            print_text_result "$model_count"
+        fi
+        return
+    fi
+
+    local usage_json=""
+    local usage_error=""
+    if usage_json="$(fetch_dashboard_usage)"; then
+        :
+    else
+        local status=$?
+        if usage_json="$(fetch_browser_dashboard_usage)"; then
+            :
+        else
+            local browser_status=$?
+            case "$status:$browser_status" in
+                3:3)
+                    usage_error="Dashboard usage requires a browser login/history match, OPENCODE_GO_WORKSPACE_ID and OPENCODE_GO_AUTH_COOKIE, or ~/.config/opencode-bar/opencode-go.json."
+                    ;;
+                4:3|4:4)
+                    usage_error="Dashboard request failed. Check workspace ID and auth cookie, or log in to opencode.ai and visit the Go dashboard once."
+                    ;;
+                *)
+                    usage_error="$(printf '%s' "$usage_json" | jq -r '.error // "Dashboard usage parsing failed."' 2>/dev/null || true)"
+                    [[ -n "$usage_error" ]] || usage_error="Dashboard usage parsing failed."
+                    ;;
+            esac
+            usage_json=""
+        fi
+    fi
+
+    if [[ -n "$usage_json" ]]; then
+        local embedded_usage_source
+        embedded_usage_source="$(jq -r '._usage_source // empty' <<<"$usage_json" 2>/dev/null || true)"
+        if [[ -n "$embedded_usage_source" ]]; then
+            USAGE_CONFIG_SOURCE="$embedded_usage_source"
+            usage_json="$(jq 'del(._usage_source)' <<<"$usage_json")"
+        fi
+    fi
+
+    if [[ "$JSON_OUTPUT" == true ]]; then
+        if [[ -n "$usage_json" ]]; then
+            print_json_result "$model_count" "$usage_json"
+        else
+            print_json_result "$model_count" "null" "$usage_error"
+        fi
+    else
+        print_text_result "$model_count" "$usage_json" "$usage_error"
+    fi
+}
+
+main "$@"

--- a/scripts/query-opencode-go.sh
+++ b/scripts/query-opencode-go.sh
@@ -375,6 +375,7 @@ def fail_quietly():
 
 
 if CRYPTO_BACKEND is None:
+    print("note: install pycryptodome or cryptography to enable browser cookie discovery", file=sys.stderr)
     fail_quietly()
 
 


### PR DESCRIPTION
- Resolves #100 
## Summary
- Add OpenCode Go as a quota-based provider across app, CLI, menu rendering, icons, subscription presets, docs, and query scripts.
- Add dashboard usage parsing for 5h, weekly, and monthly OpenCode Go windows with model API validation.
- Commonize status bar quota visibility so exhausted quota providers are hidden while any provider still has quota, with an all-exhausted exception.

## Verification
- `make lint-swift`
- `bash -n scripts/query-opencode-go.sh scripts/query-all.sh`
- `xcodebuild -project CopilotMonitor/CopilotMonitor.xcodeproj -scheme CopilotMonitor -configuration Debug -destination 'platform=macOS' -only-testing:CopilotMonitorTests/OpenCodeGoProviderTests -only-testing:CopilotMonitorTests/ProviderUsageTests test`\n- `xcodebuild -project CopilotMonitor/CopilotMonitor.xcodeproj -scheme CopilotMonitor -configuration Debug clean build`\n\n## Not Tested\n- Live OpenCode Go dashboard fetch with a real workspace cookie.